### PR TITLE
feat(tags): define canonical tag taxonomy and enforcement (closes #22)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -490,6 +490,27 @@ Due to AWS provider gaps, the core Bedrock AgentCore suite uses AWS CLI:
 
 See `docs/adr/0002-cli-based-resources.md` for migration path when native resources become available.
 
+## Canonical Tag Taxonomy
+
+All managed resources carry a deterministic set of required tags. These are enforced via:
+1. **Provider `default_tags`** in `terraform/versions.tf` — applied automatically to every AWS resource.
+2. **`local.canonical_tags`** in `terraform/locals.tf` — merged into every module's `tags` input for explicit control and for non-AWS resources.
+3. **CI validation** — `terraform/tests/validation/tags_test.sh` confirms the taxonomy is intact on every run.
+
+| Tag Key | Source | Description |
+|---------|--------|-------------|
+| `AppID` | `var.app_id` (or `var.agent_name`) | Logical application/environment boundary (North Anchor). |
+| `Environment` | `var.environment` | Deployment stage: `dev`, `staging`, or `prod`. |
+| `AgentName` | `var.agent_name` | Physical compute resource name (South Anchor). |
+| `ManagedBy` | Static: `"terraform"` | Always set; indicates this resource is Terraform-managed. |
+| `Owner` | `var.owner` (or `var.app_id`) | Team or individual owner. Defaults to `app_id` if not set. |
+
+**Override policy**: Canonical keys always win. User-supplied `var.tags` can add supplementary keys but cannot override canonical values. Set `var.owner` to assign an explicit owner identifier.
+
+**Check date**: 2026-02-22. No AWS API dependency; this is a Terraform-level convention.
+
+---
+
 ## Architecture Decision Records
 
 | ADR | Decision |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -3,4 +3,18 @@ locals {
   bedrock_region   = var.bedrock_region != "" ? var.bedrock_region : local.agentcore_region
   bff_region       = var.bff_region != "" ? var.bff_region : local.agentcore_region
   app_id           = var.app_id != "" ? var.app_id : var.agent_name
+
+  # Canonical tag taxonomy (Issue #22, Workstream B).
+  # Required keys are always present; user-supplied var.tags supplement non-canonical keys.
+  # Merge order: var.tags first, then canonical keys (canonical wins on key conflict).
+  canonical_tags = merge(
+    var.tags,
+    {
+      AppID       = local.app_id
+      Environment = var.environment
+      AgentName   = var.agent_name
+      ManagedBy   = "terraform"
+      Owner       = var.owner != "" ? var.owner : local.app_id
+    }
+  )
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,7 @@ module "agentcore_foundation" {
   region         = local.agentcore_region
   bedrock_region = local.bedrock_region
   environment    = var.environment
-  tags           = var.tags
+  tags           = local.canonical_tags
 
   # Gateway configuration
   enable_gateway      = var.enable_gateway
@@ -39,7 +39,7 @@ module "agentcore_tools" {
 
   agent_name         = var.agent_name
   region             = local.agentcore_region
-  tags               = var.tags
+  tags               = local.canonical_tags
   log_retention_days = var.log_retention_days
 
   # Code interpreter
@@ -67,7 +67,7 @@ module "agentcore_runtime" {
   region         = local.agentcore_region
   bedrock_region = local.bedrock_region
   environment    = var.environment
-  tags           = var.tags
+  tags           = local.canonical_tags
 
   # Runtime configuration
   enable_runtime          = var.enable_runtime
@@ -87,7 +87,7 @@ module "agentcore_runtime" {
   inference_profile_name             = var.inference_profile_name
   inference_profile_model_source_arn = var.inference_profile_model_source_arn
   inference_profile_description      = var.inference_profile_description
-  inference_profile_tags             = var.inference_profile_tags
+  inference_profile_tags             = merge(local.canonical_tags, var.inference_profile_tags)
 
   # S3 deployment
   deployment_bucket_name = var.deployment_bucket_name
@@ -113,7 +113,7 @@ module "agentcore_governance" {
   agent_name     = var.agent_name
   region         = local.agentcore_region
   bedrock_region = local.bedrock_region
-  tags           = var.tags
+  tags           = local.canonical_tags
 
   # Policy engine
   enable_policy_engine   = var.enable_policy_engine
@@ -167,7 +167,7 @@ module "agentcore_bff" {
   region             = local.bff_region
   agentcore_region   = local.agentcore_region
   environment        = var.environment
-  tags               = var.tags
+  tags               = local.canonical_tags
   log_retention_days = var.log_retention_days
 
   # Auth Configuration

--- a/terraform/modules/agentcore-bff/variables.tf
+++ b/terraform/modules/agentcore-bff/variables.tf
@@ -31,7 +31,7 @@ variable "agentcore_runtime_arn" {
 }
 
 variable "tags" {
-  description = "Common resource tags"
+  description = "Tags to apply to all resources. The root module always merges canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) before passing this value."
   type        = map(string)
   default     = {}
 }

--- a/terraform/modules/agentcore-foundation/variables.tf
+++ b/terraform/modules/agentcore-foundation/variables.tf
@@ -20,7 +20,7 @@ variable "environment" {
 }
 
 variable "tags" {
-  description = "Tags to apply to resources"
+  description = "Tags to apply to all resources. The root module always merges canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) before passing this value."
   type        = map(string)
   default     = {}
 }

--- a/terraform/modules/agentcore-governance/variables.tf
+++ b/terraform/modules/agentcore-governance/variables.tf
@@ -15,7 +15,7 @@ variable "bedrock_region" {
 }
 
 variable "tags" {
-  description = "Tags to apply to resources"
+  description = "Tags to apply to all resources. The root module always merges canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) before passing this value."
   type        = map(string)
   default     = {}
 }

--- a/terraform/modules/agentcore-runtime/variables.tf
+++ b/terraform/modules/agentcore-runtime/variables.tf
@@ -26,7 +26,7 @@ variable "bedrock_region" {
 }
 
 variable "tags" {
-  description = "Tags to apply to resources"
+  description = "Tags to apply to all resources. The root module always merges canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) before passing this value."
   type        = map(string)
   default     = {}
 }

--- a/terraform/modules/agentcore-tools/variables.tf
+++ b/terraform/modules/agentcore-tools/variables.tf
@@ -9,7 +9,7 @@ variable "region" {
 }
 
 variable "tags" {
-  description = "Tags to apply to resources"
+  description = "Tags to apply to all resources. The root module always merges canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) before passing this value."
   type        = map(string)
   default     = {}
 }

--- a/terraform/tests/validation/tags_test.sh
+++ b/terraform/tests/validation/tags_test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Canonical Tag Taxonomy Validation (Issue #22, Workstream B)
+#
+# Verifies that:
+#   1. The required canonical tag keys are defined in locals.tf.
+#   2. The root variables.tf declares the owner variable.
+#   3. The provider default_tags blocks include all canonical keys.
+#
+# Usage: bash terraform/tests/validation/tags_test.sh
+# Requires: no AWS credentials, no terraform init needed.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TERRAFORM_DIR="$REPO_ROOT/terraform"
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -q "$pattern" "$file"; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        Expected pattern '$pattern' in $file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=========================================="
+echo "Canonical Tag Taxonomy Validation"
+echo "=========================================="
+
+echo ""
+echo "--- locals.tf: canonical_tags local ---"
+LOCALS="$TERRAFORM_DIR/locals.tf"
+check "canonical_tags local defined"   "canonical_tags"   "$LOCALS"
+check "AppID key present"              "AppID"            "$LOCALS"
+check "Environment key present"        "Environment"      "$LOCALS"
+check "AgentName key present"          "AgentName"        "$LOCALS"
+check "ManagedBy key present"          "ManagedBy"        "$LOCALS"
+check "Owner key present"              "Owner"            "$LOCALS"
+
+echo ""
+echo "--- variables.tf: owner variable ---"
+VARS="$TERRAFORM_DIR/variables.tf"
+check "owner variable declared"        "variable \"owner\""  "$VARS"
+
+echo ""
+echo "--- versions.tf: provider default_tags ---"
+VERSIONS="$TERRAFORM_DIR/versions.tf"
+check "provider default_tags AppID"    "AppID"   "$VERSIONS"
+check "provider default_tags AgentName" "AgentName" "$VERSIONS"
+check "provider default_tags ManagedBy" "ManagedBy" "$VERSIONS"
+check "provider default_tags Owner"    "Owner"   "$VERSIONS"
+
+echo ""
+echo "--- main.tf: canonical_tags passed to all modules ---"
+MAIN="$TERRAFORM_DIR/main.tf"
+CANONICAL_COUNT=$(grep -c "canonical_tags" "$MAIN" 2>/dev/null || echo 0)
+if [ "$CANONICAL_COUNT" -ge 5 ]; then
+  echo "  PASS: canonical_tags used in $CANONICAL_COUNT module calls (>= 5 required)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: canonical_tags used in only $CANONICAL_COUNT module calls (>= 5 required)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify no bare var.tags left in module arguments (only in locals merge, which is expected)
+RAW_TAG_MODULE_REFS=$(grep -n "tags\s*=\s*var\.tags" "$MAIN" 2>/dev/null | wc -l || echo 0)
+if [ "$RAW_TAG_MODULE_REFS" -eq 0 ]; then
+  echo "  PASS: No bare 'tags = var.tags' in module calls (all use canonical_tags)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Found $RAW_TAG_MODULE_REFS bare 'tags = var.tags' in module calls"
+  grep -n "tags\s*=\s*var\.tags" "$MAIN" || true
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=========================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "PASS"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,9 +50,15 @@ variable "app_id" {
 }
 
 variable "tags" {
-  description = "Additional tags to apply to all resources"
+  description = "Additional tags to apply to all resources. Canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) are always merged by the root module; values here supplement or override non-canonical keys only."
   type        = map(string)
   default     = {}
+}
+
+variable "owner" {
+  description = "Owner identifier for resource tagging (team name, individual, or app ID). Applied as the Owner canonical tag. Defaults to app_id (or agent_name) when empty."
+  type        = string
+  default     = ""
 }
 
 # ===== FOUNDATION MODULE VARIABLES =====

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -33,8 +33,11 @@ provider "aws" {
       Terraform   = "true"
       Environment = var.environment
       Project     = "BedrockAgentCore"
-      # Note: Removed timestamp() as it causes non-idempotent plans
-      # Use lifecycle ignore_changes or external tagging if needed
+      # Canonical tag taxonomy (Issue #22) - applied to all AWS resources automatically.
+      AppID     = var.app_id != "" ? var.app_id : var.agent_name
+      AgentName = var.agent_name
+      ManagedBy = "terraform"
+      Owner     = var.owner != "" ? var.owner : (var.app_id != "" ? var.app_id : var.agent_name)
     }
   }
 }
@@ -48,6 +51,11 @@ provider "aws" {
       Terraform   = "true"
       Environment = var.environment
       Project     = "BedrockAgentCore"
+      # Canonical tag taxonomy (Issue #22) - applied to all AWS resources automatically.
+      AppID     = var.app_id != "" ? var.app_id : var.agent_name
+      AgentName = var.agent_name
+      ManagedBy = "terraform"
+      Owner     = var.owner != "" ? var.owner : (var.app_id != "" ? var.app_id : var.agent_name)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Define canonical tag taxonomy: `AppID`, `Environment`, `AgentName`, `ManagedBy`, `Owner`
- Enforce via `local.canonical_tags` (root locals) and AWS provider `default_tags` in both provider blocks
- Add `owner` variable (optional; defaults to `app_id`/`agent_name`)
- All 5 module calls in `main.tf` now pass `local.canonical_tags` instead of bare `var.tags`
- New CI validation script: `terraform/tests/validation/tags_test.sh` (13 checks, no AWS credentials required)
- Docs: added Canonical Tag Taxonomy section to `docs/architecture.md`

Closes #22

## Enforcement layers

1. **`provider default_tags`** (`versions.tf`): auto-applied to every AWS-native resource via both provider blocks
2. **`local.canonical_tags`** (`locals.tf`): merge of canonical keys over `var.tags`; passed to all module `tags` inputs
3. **CI script** (`tests/validation/tags_test.sh`): static checks confirming enforcement is intact

## Test plan

- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` — success
- [x] `bash terraform/tests/validation/tags_test.sh` — 13/13 passed
- [x] `checkov` — 94 passed, 0 failed, 12 skipped
- [x] `tflint` — clean
- [x] `make preflight-session` — PASS

## Validation evidence

```
Results: 13 passed, 0 failed   (tags_test.sh)
Passed checks: 94, Failed checks: 0, Skipped checks: 12   (checkov)
Success! The configuration is valid.   (terraform validate)
Preflight result: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)