### PR TITLE
refactor(novation): decommission legacy gateway cli path (#21)

### DIFF
--- a/docs/NOVATION_MATRIX.md
+++ b/docs/NOVATION_MATRIX.md
@@ -13,8 +13,8 @@ This document tracks the migration of Bedrock AgentCore resources from CLI-manag
 
 | CLI Resource | Module | Terraform Native Resource | Status | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| `null_resource.gateway` | Foundation | `aws_bedrockagentcore_gateway` | **pilot-complete** | Pilot in v6.33.0+ (Issue #18) |
-| `null_resource.gateway_target` | Foundation | `aws_bedrockagentcore_gateway_target` | **pilot-complete** | Pilot in v6.33.0+ (Issue #18) |
+| `null_resource.gateway` | Foundation | `aws_bedrockagentcore_gateway` | **native-now** | Native path stabilized; legacy CLI branch decommissioned (Issue #21) |
+| `null_resource.gateway_target` | Foundation | `aws_bedrockagentcore_gateway_target` | **native-now** | Native path stabilized; legacy CLI branch decommissioned (Issue #21) |
 | `null_resource.workload_identity` | Foundation | (part of `aws_bedrockagentcore_*`) | **native-now** | Implicit or nested in Gateway/Runtime |
 | `null_resource.agent_runtime` | Runtime | `aws_bedrockagentcore_agent_runtime` | **native-now** | Full support in v6.32+ |
 | `null_resource.agent_memory` | Runtime | `aws_bedrockagentcore_memory` | **native-now** | Full support in v6.33+ |
@@ -53,3 +53,4 @@ aws = {
 ## 📅 Revision History
 
 - **2026-02-22**: Initial matrix creation (Issue #17).
+- **2026-02-22**: Gateway and gateway target moved from `pilot-complete` to `native-now` after legacy CLI decommission (Issue #21).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,8 +160,8 @@ agentcore-foundation (NO dependencies)
 **Purpose**: Core infrastructure (Gateway, Identity, Observability)
 
 **Resources**:
-- `null_resource` + CLI for Gateway (MCP protocol gateway)
-- `null_resource` + CLI for Gateway Target (MCP Lambda targets)
+- `aws_bedrockagentcore_gateway` - MCP protocol gateway (native provider)
+- `aws_bedrockagentcore_gateway_target` - MCP Lambda targets (native provider)
 - `null_resource` + CLI for Workload Identity (OAuth2 identity)
 - `aws_cloudwatch_log_group` - Centralized logging
 - `aws_xray_sampling_rule` - Distributed tracing
@@ -477,7 +477,6 @@ Due to AWS provider gaps, the core Bedrock AgentCore suite uses AWS CLI:
 
 | Resource | CLI Command |
 |----------|------------|
-| Gateway | `bedrock-agentcore-control create-gateway` |
 | Identity | `bedrock-agentcore-control create-workload-identity` |
 | Browser | `bedrock-agentcore-control create-browser` |
 | Code Interpreter | `bedrock-agentcore-control create-code-interpreter` |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,7 +13,6 @@ module "agentcore_foundation" {
 
   # Gateway configuration
   enable_gateway      = var.enable_gateway
-  use_native_gateway  = var.use_native_gateway
   gateway_name        = var.gateway_name
   gateway_role_arn    = var.gateway_role_arn
   mcp_targets         = var.mcp_targets

--- a/terraform/modules/agentcore-foundation/README.md
+++ b/terraform/modules/agentcore-foundation/README.md
@@ -4,7 +4,7 @@
 This module manages the base infrastructure for a Bedrock Agent, including the MCP Gateway, Workload Identity, and Observability stacks.
 
 ## Features
-- **MCP Gateway**: CLI-based provisioning of the tool gateway.
+- **MCP Gateway**: Native AWS provider provisioning for the tool gateway and targets.
 - **Identity**: ABAC-hardened IAM roles for agent workloads.
 - **Observability**: CloudWatch Log Groups and X-Ray tracing.
 
@@ -15,16 +15,16 @@ This module manages the base infrastructure for a Bedrock Agent, including the M
 ## Known Failure Modes (Rule 16)
 
 ### 1. Partial Provisioning (CLI Timeout)
-- **Symptom**: `null_resource.gateway` fails mid-execution.
-- **Impact**: AWS resource may be created but not recorded in SSM.
+- **Symptom**: `null_resource.workload_identity` fails mid-execution.
+- **Impact**: Workload identity may be created but not recorded in SSM.
 - **Recovery**:
-  1. Manually identify the resource ID via AWS CLI: `aws bedrock-agentcore-control list-gateways`.
-  2. Manually populate SSM: `aws ssm put-parameter --name "/agentcore/<agent_name>/gateway/id" --value "<id>" --type "String" --overwrite`.
+  1. Manually identify the resource ID via AWS CLI: `aws bedrock-agentcore-control list-workload-identities`.
+  2. Manually populate SSM: `aws ssm put-parameter --name "/agentcore/<agent_name>/identity/id" --value "<id>" --type "String" --overwrite`.
   3. Re-run `terraform apply`.
 
-### 2. Zombie Gateway
-- **Symptom**: `terraform destroy` fails to delete the gateway.
+### 2. Zombie Workload Identity
+- **Symptom**: `terraform destroy` fails to delete the workload identity.
 - **Recovery**:
-  1. Get ID from SSM: `aws ssm get-parameter --name "/agentcore/<agent_name>/gateway/id"`.
-  2. Manually delete: `aws bedrock-agentcore-control delete-gateway --gateway-identifier <id>`.
-  3. Cleanup SSM: `aws ssm delete-parameter --name "/agentcore/<agent_name>/gateway/id"`.
+  1. Get ID from SSM: `aws ssm get-parameter --name "/agentcore/<agent_name>/identity/id"`.
+  2. Manually delete: `aws bedrock-agentcore-control delete-workload-identity --workload-identity-identifier <id>`.
+  3. Cleanup SSM: `aws ssm delete-parameter --name "/agentcore/<agent_name>/identity/id"`.

--- a/terraform/modules/agentcore-foundation/gateway.tf
+++ b/terraform/modules/agentcore-foundation/gateway.tf
@@ -1,9 +1,9 @@
 # Note: Using AWS-managed encryption (SSE-S3/AES256) instead of customer-managed KMS
 # This simplifies operations while maintaining security through AWS's default encryption
 
-# MCP Gateway - Pilot Native Resource (Workstream A)
+# MCP Gateway - Native Resource (Workstream A)
 resource "aws_bedrockagentcore_gateway" "this" {
-  count = var.use_native_gateway && var.enable_gateway ? 1 : 0
+  count = var.enable_gateway ? 1 : 0
 
   name            = var.gateway_name != "" ? var.gateway_name : "${var.agent_name}-gateway"
   role_arn        = aws_iam_role.gateway[0].arn
@@ -14,7 +14,7 @@ resource "aws_bedrockagentcore_gateway" "this" {
     mcp {
       # Provider v6.33.0 native gateway currently validates search_type as SEMANTIC.
       # Preserve existing module input compatibility while forcing a provider-supported
-      # value for the native pilot path.
+      # value for the native path.
       search_type        = var.gateway_search_type == "HYBRID" ? "SEMANTIC" : var.gateway_search_type
       supported_versions = var.gateway_mcp_versions
     }
@@ -28,9 +28,9 @@ resource "aws_bedrockagentcore_gateway" "this" {
   ]
 }
 
-# MCP Gateway Targets - Pilot Native Resource (Workstream A)
+# MCP Gateway Targets - Native Resource (Workstream A)
 resource "aws_bedrockagentcore_gateway_target" "this" {
-  for_each = var.use_native_gateway && var.enable_gateway ? var.mcp_targets : {}
+  for_each = var.enable_gateway ? var.mcp_targets : {}
 
   name               = each.value.name
   gateway_identifier = aws_bedrockagentcore_gateway.this[0].gateway_id
@@ -59,175 +59,6 @@ resource "aws_bedrockagentcore_gateway_target" "this" {
 
   depends_on = [aws_bedrockagentcore_gateway.this]
 }
-
-# MCP Gateway - Legacy CLI-based provisioning (deprecated)
-resource "null_resource" "gateway" {
-  count = !var.use_native_gateway && var.enable_gateway ? 1 : 0
-
-  triggers = {
-    agent_name    = var.agent_name
-    region        = var.region
-    name          = var.gateway_name != "" ? var.gateway_name : "${var.agent_name}-gateway"
-    role_arn      = aws_iam_role.gateway[0].arn
-    protocol_type = "MCP"
-    search_type   = var.gateway_search_type
-    versions      = join(",", var.gateway_mcp_versions)
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      set -e
-      mkdir -p "${path.module}/.terraform"
-
-      echo "Creating MCP Gateway..."
-
-      aws bedrock-agentcore-control create-gateway \
-        --name "${self.triggers.name}" \
-        --role-arn "${self.triggers.role_arn}" \
-        --protocol-type "MCP" \
-        --protocol-configuration "{\"mcp\":{\"searchType\":\"${self.triggers.search_type}\",\"supportedVersions\":${jsonencode(var.gateway_mcp_versions)}}}" \
-        --region ${self.triggers.region} \
-        --output json > "${path.module}/.terraform/gateway_output.json"
-
-      # Rule 1.2: Fail Fast
-      if [ ! -s "${path.module}/.terraform/gateway_output.json" ]; then
-        echo "ERROR: Failed to create gateway"
-        exit 1
-      fi
-
-      # Capture metadata
-      GATEWAY_ID=$(jq -r '.gatewayId' < "${path.module}/.terraform/gateway_output.json")
-      GATEWAY_ARN=$(jq -r '.gatewayArn' < "${path.module}/.terraform/gateway_output.json")
-      GATEWAY_ENDPOINT=$(jq -r '.gatewayEndpoint' < "${path.module}/.terraform/gateway_output.json")
-
-      # Rule 5.1: SSM Persistence Pattern
-      echo "Persisting Gateway metadata to SSM..."
-      aws ssm put-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/id" --value "$GATEWAY_ID" --type "String" --overwrite --region ${self.triggers.region}
-      aws ssm put-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/arn" --value "$GATEWAY_ARN" --type "String" --overwrite --region ${self.triggers.region}
-      aws ssm put-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/endpoint" --value "$GATEWAY_ENDPOINT" --type "String" --overwrite --region ${self.triggers.region}
-
-      # Temporary local storage for immediate data source consumption in same plan
-      echo "$GATEWAY_ID" > "${path.module}/.terraform/gateway_id.txt"
-    EOT
-
-    interpreter = ["bash", "-c"]
-  }
-
-  # Rule 6.1: Mandatory Destroy Provisioners
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      set +e
-
-      GATEWAY_ID=$(aws ssm get-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/id" --query "Parameter.Value" --output text --region ${self.triggers.region} 2>/dev/null)
-
-      if [ -z "$GATEWAY_ID" ]; then
-        echo "WARN: Could not find Gateway ID in SSM for ${self.triggers.agent_name}, skipping AWS resource deletion"
-      else
-        echo "Deleting Gateway $GATEWAY_ID..."
-        aws bedrock-agentcore-control delete-gateway --gateway-identifier "$GATEWAY_ID" --region ${self.triggers.region}
-
-        echo "Cleaning up SSM parameter..."
-        aws ssm delete-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/id" --region ${self.triggers.region}
-      fi
-    EOT
-
-    interpreter = ["bash", "-c"]
-  }
-
-  depends_on = [
-    aws_iam_role.gateway,
-    aws_iam_role_policy.gateway
-  ]
-}
-
-# Data source to read the ID from SSM (Legacy CLI Bridge)
-data "aws_ssm_parameter" "gateway_id" {
-  count = !var.use_native_gateway && var.enable_gateway ? 1 : 0
-  name  = "/agentcore/${var.agent_name}/gateway/id"
-
-  depends_on = [null_resource.gateway]
-}
-
-data "aws_ssm_parameter" "gateway_arn" {
-  count = !var.use_native_gateway && var.enable_gateway ? 1 : 0
-  name  = "/agentcore/${var.agent_name}/gateway/arn"
-
-  depends_on = [null_resource.gateway]
-}
-
-data "aws_ssm_parameter" "gateway_endpoint" {
-  count = !var.use_native_gateway && var.enable_gateway ? 1 : 0
-  name  = "/agentcore/${var.agent_name}/gateway/endpoint"
-
-  depends_on = [null_resource.gateway]
-}
-
-# Gateway MCP Targets - Legacy CLI-based provisioning (deprecated)
-resource "null_resource" "gateway_target" {
-  for_each = !var.use_native_gateway && var.enable_gateway ? var.mcp_targets : {}
-
-  triggers = {
-    agent_name = var.agent_name
-    region     = var.region
-    name       = each.value.name
-    lambda_arn = each.value.lambda_arn
-    gateway_id = var.enable_gateway ? data.aws_ssm_parameter.gateway_id[0].value : ""
-    target_key = each.key
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      set -e
-      mkdir -p "${path.module}/.terraform"
-
-      echo "Creating Gateway Target: ${self.triggers.name}..."
-
-      aws bedrock-agentcore-control create-gateway-target \
-        --name "${self.triggers.name}" \
-        --gateway-identifier "${self.triggers.gateway_id}" \
-        --target-configuration "{\"mcp\":{\"lambda\":{\"lambdaArn\":\"${self.triggers.lambda_arn}\"}}}" \
-        --region ${self.triggers.region} \
-        --output json > "${path.module}/.terraform/target_${self.triggers.target_key}.json"
-
-      if [ ! -s "${path.module}/.terraform/target_${self.triggers.target_key}.json" ]; then
-        echo "ERROR: Failed to create target ${self.triggers.name}"
-        exit 1
-      fi
-
-      TARGET_ID=$(jq -r '.targetId' < "${path.module}/.terraform/target_${self.triggers.target_key}.json")
-
-      # Persist Target ID
-      aws ssm put-parameter \
-        --name "/agentcore/${self.triggers.agent_name}/gateway/targets/${self.triggers.target_key}/id" \
-        --value "$TARGET_ID" \
-        --type "String" \
-        --overwrite \
-        --region ${self.triggers.region}
-    EOT
-
-    interpreter = ["bash", "-c"]
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOT
-      set +e
-      TARGET_ID=$(aws ssm get-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/targets/${self.triggers.target_key}/id" --query "Parameter.Value" --output text --region ${self.triggers.region} 2>/dev/null)
-
-      if [ -n "$TARGET_ID" ]; then
-        echo "Deleting Gateway Target $TARGET_ID..."
-        aws bedrock-agentcore-control delete-gateway-target --gateway-identifier "${self.triggers.gateway_id}" --target-identifier "$TARGET_ID" --region ${self.triggers.region}
-        aws ssm delete-parameter --name "/agentcore/${self.triggers.agent_name}/gateway/targets/${self.triggers.target_key}/id" --region ${self.triggers.region}
-      fi
-    EOT
-
-    interpreter = ["bash", "-c"]
-  }
-
-  depends_on = [null_resource.gateway]
-}
-
 # CloudWatch Log Group for Gateway
 resource "aws_cloudwatch_log_group" "gateway" {
   count = var.enable_gateway && var.enable_observability ? 1 : 0

--- a/terraform/modules/agentcore-foundation/locals.tf
+++ b/terraform/modules/agentcore-foundation/locals.tf
@@ -1,22 +1,8 @@
-# Unified outputs for Gateway (CLI vs Native)
+# Native gateway outputs
 locals {
-  use_native = var.use_native_gateway && var.enable_gateway
+  gateway_id = var.enable_gateway && length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_id : null
 
-  gateway_id = local.use_native ? (
-    length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_id : null
-    ) : (
-    var.enable_gateway && length(data.aws_ssm_parameter.gateway_id) > 0 ? data.aws_ssm_parameter.gateway_id[0].value : null
-  )
+  gateway_arn = var.enable_gateway && length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_arn : null
 
-  gateway_arn = local.use_native ? (
-    length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_arn : null
-    ) : (
-    var.enable_gateway && length(data.aws_ssm_parameter.gateway_arn) > 0 ? data.aws_ssm_parameter.gateway_arn[0].value : null
-  )
-
-  gateway_endpoint = local.use_native ? (
-    length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_url : null
-    ) : (
-    var.enable_gateway && length(data.aws_ssm_parameter.gateway_endpoint) > 0 ? data.aws_ssm_parameter.gateway_endpoint[0].value : null
-  )
+  gateway_endpoint = var.enable_gateway && length(aws_bedrockagentcore_gateway.this) > 0 ? aws_bedrockagentcore_gateway.this[0].gateway_url : null
 }

--- a/terraform/modules/agentcore-foundation/observability.tf
+++ b/terraform/modules/agentcore-foundation/observability.tf
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_metric_alarm" "gateway_errors" {
   alarm_actions       = var.alarm_sns_topic_arn != "" ? [var.alarm_sns_topic_arn] : []
 
   dimensions = {
-    GatewayId = var.enable_gateway ? data.aws_ssm_parameter.gateway_id[0].value : ""
+    GatewayId = local.gateway_id
   }
 
   tags = var.tags
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "target_duration" {
   alarm_actions       = var.alarm_sns_topic_arn != "" ? [var.alarm_sns_topic_arn] : []
 
   dimensions = {
-    GatewayId = var.enable_gateway ? data.aws_ssm_parameter.gateway_id[0].value : ""
+    GatewayId = local.gateway_id
   }
 
   tags = var.tags

--- a/terraform/modules/agentcore-foundation/variables.tf
+++ b/terraform/modules/agentcore-foundation/variables.tf
@@ -1,10 +1,3 @@
-# Pilot Features (Workstream A)
-variable "use_native_gateway" {
-  description = "Whether to use native AWS provider resources for Gateway (Pilot). If true, null_resource CLI bridges are bypassed."
-  type        = bool
-  default     = false
-}
-
 variable "agent_name" {
   description = "Name of the agent"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,13 +33,6 @@ variable "environment" {
   }
 }
 
-# Pilot Features (Workstream A)
-variable "use_native_gateway" {
-  description = "Whether to use native AWS provider resources for Gateway (Pilot). If true, null_resource CLI bridges are bypassed."
-  type        = bool
-  default     = false
-}
-
 variable "agent_name" {
   description = "Name of the agent"
   type        = string


### PR DESCRIPTION
## Summary
- remove the deprecated gateway/gateway-target CLI fallback branches and `use_native_gateway` pilot toggle
- keep CLI-required foundation identity path intact while rewiring gateway outputs/alarms to native gateway IDs
- update validation/docs to reflect gateway native-only provisioning in the foundation module

## Validation
- `terraform -chdir=terraform fmt -check -recursive`
- `python3 terraform/tests/validation/test_remediation_integrity.py`
- `terraform -chdir=terraform init -backend=false -input=false`
- `terraform -chdir=terraform validate`

## Notes
- Scope intentionally limited to migrated/stabilized gateway family per Issue #21.
- CLI-required resources remain unchanged (browser, code interpreter, policy engine, cedar policies, evaluators, etc.).
