### PR TITLE
fix: enforce claim-scoped tenancy authorization in portal API BFF authorizer (#27)

### DIFF
--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -7,6 +7,7 @@ This module implements the **Serverless Token Handler Pattern** (ADR 0011) to se
 *   **Frontend**: S3 + CloudFront (SPA Hosting).
 *   **API**: Amazon API Gateway (REST).
 *   **Auth**: "Token Handler" Lambdas (Login/Callback) + DynamoDB Session Store.
+    The request authorizer validates the session cookie against the stored session record and JWT tenant claims before allowing `/api/*` calls.
 *   **Proxy**: Lambda Proxy to AgentCore Runtime (`InvokeAgentRuntime`) with streaming response support (Node.js runtime).
 
 ## Usage
@@ -48,7 +49,7 @@ The proxy streams `application/x-ndjson` where each line is a JSON object:
 
 ### 2. 403 Forbidden on `/api/chat`
 *   **Cause**: Invalid or expired Session Cookie.
-*   **Fix**: Clear browser cookies. Check DynamoDB table for session existence and TTL. Check `agentcore-bff-authz-*` logs.
+*   **Fix**: Clear browser cookies. Check DynamoDB table for session existence and TTL. Check `agentcore-bff-authz-*` logs. The authorizer also denies if the cookie tenant/session does not match the stored session or JWT tenant claim.
 
 ### 3. SPA 403 Access Denied
 *   **Cause**: CloudFront OAC permission issue or S3 bucket policy sync delay.


### PR DESCRIPTION
## Summary
- enforce claim-scoped tenant validation in the BFF Lambda authorizer (cookie -> session record -> JWT claim consistency)
- deny requests when session cookie tenant/session or app scope do not match the stored session record
- propagate principal identity fields from JWT claims in authorizer context for downstream portal/API checks
- add authorizer tenancy mismatch tests and document the 403 denial condition in the BFF module README

## Validation
- `make preflight-session` (PASS, before work and before commit/push)
- `python3 -m pytest terraform/modules/agentcore-bff/tests/test_multi_tenancy.py -v --tb=short` (3 passed)
- `python3 -m pytest terraform/modules/agentcore-bff/tests -v --tb=short` (5 passed)
- `python3 -m pytest terraform/tests/validation/test_tenancy_admin_api_contract_v1.py -v --tb=short` (4 passed)
- `python3 -m py_compile terraform/modules/agentcore-bff/src/authorizer.py terraform/modules/agentcore-bff/src/auth_handler.py` (PASS)
- `git diff --check -- terraform/modules/agentcore-bff/src/authorizer.py terraform/modules/agentcore-bff/tests/test_multi_tenancy.py terraform/modules/agentcore-bff/README.md` (PASS)

## Notes
- `npm test` in `terraform/modules/agentcore-bff/src` could not run in this environment because `jest` is not installed (`sh: 1: jest: not found`).

Closes #27
