### PR TITLE
feat(dx): implement native OpenAPI generation for MCP tools (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
+- MCP Tools OpenAPI 3.1.0 specification generation from the tool registry in `examples/mcp-servers/` (Issue #33).
+- New `make generate-openapi` target in root `Makefile` to update the specification file at `docs/api/mcp-tools-v1.openapi.json`.
 - Resource Coverage Matrix (`docs/NOVATION_MATRIX.md`) identifying migration candidates from CLI to native Terraform (Issue #17).
 - AWS Provider version pin to `~> 6.33.0` to support native Bedrock AgentCore resources (Issue #17).
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -98,6 +98,22 @@ git push origin main
 cd terraform
 terraform fmt -check -recursive
 
+# Generate all documentation (including MCP Tools OpenAPI)
+make docs
+```
+
+#### MCP Tools OpenAPI Generation
+
+The project includes a script to automatically generate an OpenAPI 3.1.0 specification from the MCP tools registry defined in `examples/mcp-servers/*/handler.py`.
+
+To generate or update the OpenAPI spec:
+
+```bash
+make generate-openapi
+```
+
+The generated file will be saved to `docs/api/mcp-tools-v1.openapi.json`. This spec can be used by the Web UI to dynamically build tool-calling interfaces or for testing.
+
 # Syntax validation
 terraform validate
 

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,15 @@ tflint: ## Run TFLint for style checking
 	tflint --chdir=$(TERRAFORM_DIR) --format compact --config $(TERRAFORM_DIR)/.tflint.hcl
 
 # Documentation
-docs: ## Generate Terraform documentation
-	@echo "Generating documentation..."
+docs: generate-openapi ## Generate all documentation (Terraform + OpenAPI)
+	@echo "Generating Terraform documentation..."
 	terraform-docs markdown $(TERRAFORM_DIR) > docs/terraform.md
 	@echo "✓ Documentation generated to docs/terraform.md"
+
+generate-openapi: ## Generate OpenAPI spec from MCP tools registry
+	@echo "Generating OpenAPI spec..."
+	python3 terraform/scripts/generate_mcp_openapi.py
+	@echo "✓ OpenAPI spec generated to docs/api/mcp-tools-v1.openapi.json"
 
 # Module management
 module-list: ## List all modules

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ This document outlines planned features and improvements for the Bedrock AgentCo
 
 ## 🛠️ Developer Experience (DX)
 
-- [ ] **Native Swagger/OpenAPI Generation**
+- [x] **Native Swagger/OpenAPI Generation**
   * **Problem:** MCP tools are defined in code but not documented for the frontend.
   * **Solution:** Automatically generate an OpenAPI spec from the MCP tools registry for use in the Web UI.
   * **Issue:** #33

--- a/docs/api/mcp-tools-v1.openapi.json
+++ b/docs/api/mcp-tools-v1.openapi.json
@@ -1,0 +1,858 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AgentCore MCP Tools API",
+    "version": "1.0.0",
+    "description": "Automatically generated OpenAPI spec from MCP tools registry."
+  },
+  "paths": {
+    "/tools/awscli-tools/run_command": {
+      "post": {
+        "tags": [
+          "awscli-tools"
+        ],
+        "summary": "Run a specific AWS API command",
+        "operationId": "awscli-tools_run_command",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "service": {
+                    "type": "string",
+                    "description": "AWS service name (e.g., 's3', 'ec2')"
+                  },
+                  "operation": {
+                    "type": "string",
+                    "description": "Boto3 method name (e.g., 'list_buckets', 'describe_instances')"
+                  },
+                  "parameters": {
+                    "type": "string",
+                    "description": "Dictionary of arguments for the method"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/s3-tools/list_buckets": {
+      "post": {
+        "tags": [
+          "s3-tools"
+        ],
+        "summary": "List S3 buckets",
+        "operationId": "s3-tools_list_buckets",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string",
+                    "description": "Optional bucket name prefix filter"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/s3-tools/list_objects": {
+      "post": {
+        "tags": [
+          "s3-tools"
+        ],
+        "summary": "List objects in a bucket",
+        "operationId": "s3-tools_list_objects",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bucket": {
+                    "type": "string",
+                    "description": "Bucket name (required)"
+                  },
+                  "prefix": {
+                    "type": "string",
+                    "description": "Object key prefix filter"
+                  },
+                  "max_keys": {
+                    "type": "string",
+                    "description": "Maximum objects to return"
+                  },
+                  "delimiter": {
+                    "type": "string",
+                    "description": "Delimiter for hierarchy"
+                  }
+                },
+                "required": [
+                  "bucket"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/s3-tools/get_object": {
+      "post": {
+        "tags": [
+          "s3-tools"
+        ],
+        "summary": "Get object content from S3",
+        "operationId": "s3-tools_get_object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bucket": {
+                    "type": "string",
+                    "description": "Bucket name (required)"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Object key (required)"
+                  },
+                  "encoding": {
+                    "type": "string",
+                    "description": "Content encoding: text, base64, json"
+                  },
+                  "max_size": {
+                    "type": "string",
+                    "description": "Maximum size to read in bytes"
+                  }
+                },
+                "required": [
+                  "bucket",
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/s3-tools/put_object": {
+      "post": {
+        "tags": [
+          "s3-tools"
+        ],
+        "summary": "Upload content to S3",
+        "operationId": "s3-tools_put_object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bucket": {
+                    "type": "string",
+                    "description": "Bucket name (required)"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Object key (required)"
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "Content to upload (required)"
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "description": "MIME type"
+                  },
+                  "encoding": {
+                    "type": "string",
+                    "description": "Content encoding: text or base64"
+                  }
+                },
+                "required": [
+                  "bucket",
+                  "key",
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/s3-tools/get_object_metadata": {
+      "post": {
+        "tags": [
+          "s3-tools"
+        ],
+        "summary": "Get object metadata",
+        "operationId": "s3-tools_get_object_metadata",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bucket": {
+                    "type": "string",
+                    "description": "Bucket name (required)"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Object key (required)"
+                  }
+                },
+                "required": [
+                  "bucket",
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/titanic-data/fetch_dataset": {
+      "post": {
+        "tags": [
+          "titanic-data"
+        ],
+        "summary": "Fetch Titanic passenger data",
+        "operationId": "titanic-data_fetch_dataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "string",
+                    "description": "Maximum rows to return"
+                  },
+                  "offset": {
+                    "type": "string",
+                    "description": "Rows to skip"
+                  },
+                  "columns": {
+                    "type": "string",
+                    "description": "List of columns to include"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/titanic-data/get_schema": {
+      "post": {
+        "tags": [
+          "titanic-data"
+        ],
+        "summary": "Get dataset schema and column information",
+        "operationId": "titanic-data_get_schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/titanic-data/query": {
+      "post": {
+        "tags": [
+          "titanic-data"
+        ],
+        "summary": "Query dataset with filters",
+        "operationId": "titanic-data_query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "string",
+                    "description": "Column:value filter pairs"
+                  },
+                  "columns": {
+                    "type": "string",
+                    "description": "Columns to return"
+                  },
+                  "limit": {
+                    "type": "string",
+                    "description": "Maximum rows"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/titanic-data/get_statistics": {
+      "post": {
+        "tags": [
+          "titanic-data"
+        ],
+        "summary": "Get summary statistics",
+        "operationId": "titanic-data_get_statistics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "columns": {
+                    "type": "string",
+                    "description": "Columns to analyze"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/echo": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Echo back input message",
+        "operationId": "local-dev_echo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Message to echo back"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/store_value": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Store a key-value pair",
+        "operationId": "local-dev_store_value",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "Storage key (required)"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Value to store"
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/get_value": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Retrieve a stored value",
+        "operationId": "local-dev_get_value",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "Storage key (required)"
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/list_keys": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "List all stored keys",
+        "operationId": "local-dev_list_keys",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string",
+                    "description": "Optional key prefix filter"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/delete_value": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Delete a stored value",
+        "operationId": "local-dev_delete_value",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "Storage key (required)"
+                  }
+                },
+                "required": [
+                  "key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/add_memory": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Add entry to conversation memory",
+        "operationId": "local-dev_add_memory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "description": "Memory content (required)"
+                  },
+                  "role": {
+                    "type": "string",
+                    "description": "Role (user/assistant)"
+                  }
+                },
+                "required": [
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/get_memory": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Retrieve conversation memory",
+        "operationId": "local-dev_get_memory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "string",
+                    "description": "Maximum entries to return"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/clear_memory": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Clear all conversation memory",
+        "operationId": "local-dev_clear_memory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/get_env": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Get environment information",
+        "operationId": "local-dev_get_env",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tools/local-dev/calculate": {
+      "post": {
+        "tags": [
+          "local-dev"
+        ],
+        "summary": "Perform simple calculations",
+        "operationId": "local-dev_calculate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expression": {
+                    "type": "string",
+                    "description": "Math expression (required)"
+                  }
+                },
+                "required": [
+                  "expression"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful tool execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ToolResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "result": {
+            "type": "object"
+          },
+          "error": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "awscli-tools",
+      "description": "Tools from awscli-tools MCP server"
+    },
+    {
+      "name": "s3-tools",
+      "description": "Tools from s3-tools MCP server"
+    },
+    {
+      "name": "titanic-data",
+      "description": "Tools from titanic-data MCP server"
+    },
+    {
+      "name": "local-dev",
+      "description": "Tools from local-dev MCP server"
+    }
+  ]
+}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,126 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.33.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.4 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.33.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | ~> 3.4 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_agentcore_bff"></a> [agentcore\_bff](#module\_agentcore\_bff) | ./modules/agentcore-bff | n/a |
+| <a name="module_agentcore_foundation"></a> [agentcore\_foundation](#module\_agentcore\_foundation) | ./modules/agentcore-foundation | n/a |
+| <a name="module_agentcore_governance"></a> [agentcore\_governance](#module\_agentcore\_governance) | ./modules/agentcore-governance | n/a |
+| <a name="module_agentcore_runtime"></a> [agentcore\_runtime](#module\_agentcore\_runtime) | ./modules/agentcore-runtime | n/a |
+| <a name="module_agentcore_tools"></a> [agentcore\_tools](#module\_agentcore\_tools) | ./modules/agentcore-tools | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [http_http.oidc_config](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_agent_name"></a> [agent\_name](#input\_agent\_name) | Name of the agent | `string` | n/a | yes |
+| <a name="input_agentcore_region"></a> [agentcore\_region](#input\_agentcore\_region) | Optional AgentCore control-plane region override (defaults to region) | `string` | `""` | no |
+| <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | Optional SNS topic ARN for CloudWatch alarm notifications | `string` | `""` | no |
+| <a name="input_app_id"></a> [app\_id](#input\_app\_id) | Application ID for multi-tenant isolation (North anchor). Defaults to agent\_name. | `string` | `""` | no |
+| <a name="input_bedrock_region"></a> [bedrock\_region](#input\_bedrock\_region) | Optional Bedrock region override for model-related resources (defaults to agentcore\_region) | `string` | `""` | no |
+| <a name="input_bff_agentcore_runtime_arn"></a> [bff\_agentcore\_runtime\_arn](#input\_bff\_agentcore\_runtime\_arn) | AgentCore runtime ARN for the BFF proxy (required if enable\_bff is true and enable\_runtime is false) | `string` | `""` | no |
+| <a name="input_bff_region"></a> [bff\_region](#input\_bff\_region) | Optional BFF/API Gateway region override (defaults to agentcore\_region) | `string` | `""` | no |
+| <a name="input_browser_network_mode"></a> [browser\_network\_mode](#input\_browser\_network\_mode) | Network mode for browser (PUBLIC, SANDBOX, VPC) | `string` | `"SANDBOX"` | no |
+| <a name="input_browser_recording_s3_bucket"></a> [browser\_recording\_s3\_bucket](#input\_browser\_recording\_s3\_bucket) | S3 bucket for browser session recordings | `string` | `""` | no |
+| <a name="input_browser_vpc_config"></a> [browser\_vpc\_config](#input\_browser\_vpc\_config) | VPC configuration for browser | <pre>object({<br/>    subnet_ids          = list(string)<br/>    security_group_ids  = list(string)<br/>    associate_public_ip = optional(bool, false)<br/>  })</pre> | `null` | no |
+| <a name="input_cedar_policy_files"></a> [cedar\_policy\_files](#input\_cedar\_policy\_files) | Map of policy names to Cedar policy file paths | `map(string)` | `{}` | no |
+| <a name="input_code_interpreter_network_mode"></a> [code\_interpreter\_network\_mode](#input\_code\_interpreter\_network\_mode) | Network mode for code interpreter (PUBLIC, SANDBOX, VPC) | `string` | `"SANDBOX"` | no |
+| <a name="input_code_interpreter_vpc_config"></a> [code\_interpreter\_vpc\_config](#input\_code\_interpreter\_vpc\_config) | VPC configuration for code interpreter | <pre>object({<br/>    subnet_ids          = list(string)<br/>    security_group_ids  = list(string)<br/>    associate_public_ip = optional(bool, false)<br/>  })</pre> | `null` | no |
+| <a name="input_deployment_bucket_name"></a> [deployment\_bucket\_name](#input\_deployment\_bucket\_name) | S3 bucket name for deployment artifacts | `string` | `""` | no |
+| <a name="input_enable_bff"></a> [enable\_bff](#input\_enable\_bff) | Enable the Serverless SPA/BFF module | `bool` | `false` | no |
+| <a name="input_enable_browser"></a> [enable\_browser](#input\_enable\_browser) | Enable web browser tool | `bool` | `false` | no |
+| <a name="input_enable_browser_recording"></a> [enable\_browser\_recording](#input\_enable\_browser\_recording) | Enable session recording for browser | `bool` | `false` | no |
+| <a name="input_enable_code_interpreter"></a> [enable\_code\_interpreter](#input\_enable\_code\_interpreter) | Enable Python code interpreter | `bool` | `true` | no |
+| <a name="input_enable_evaluations"></a> [enable\_evaluations](#input\_enable\_evaluations) | Enable agent evaluation system | `bool` | `false` | no |
+| <a name="input_enable_gateway"></a> [enable\_gateway](#input\_enable\_gateway) | Enable MCP gateway for tool integration | `bool` | `true` | no |
+| <a name="input_enable_guardrails"></a> [enable\_guardrails](#input\_enable\_guardrails) | Enable Bedrock Guardrails | `bool` | `false` | no |
+| <a name="input_enable_identity"></a> [enable\_identity](#input\_enable\_identity) | Enable workload identity | `bool` | `false` | no |
+| <a name="input_enable_inference_profile"></a> [enable\_inference\_profile](#input\_enable\_inference\_profile) | Enable Bedrock application inference profile creation | `bool` | `false` | no |
+| <a name="input_enable_kms"></a> [enable\_kms](#input\_enable\_kms) | Enable KMS encryption for logs and artifacts | `bool` | `false` | no |
+| <a name="input_enable_memory"></a> [enable\_memory](#input\_enable\_memory) | Enable agent memory | `bool` | `false` | no |
+| <a name="input_enable_observability"></a> [enable\_observability](#input\_enable\_observability) | Enable CloudWatch and X-Ray observability | `bool` | `true` | no |
+| <a name="input_enable_packaging"></a> [enable\_packaging](#input\_enable\_packaging) | Enable two-stage build process | `bool` | `true` | no |
+| <a name="input_enable_policy_engine"></a> [enable\_policy\_engine](#input\_enable\_policy\_engine) | Enable Cedar policy engine | `bool` | `false` | no |
+| <a name="input_enable_runtime"></a> [enable\_runtime](#input\_enable\_runtime) | Enable agent runtime | `bool` | `true` | no |
+| <a name="input_enable_s3_encryption"></a> [enable\_s3\_encryption](#input\_enable\_s3\_encryption) | Enable S3 encryption | `bool` | `true` | no |
+| <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable WAF protection for API Gateway | `bool` | `false` | no |
+| <a name="input_enable_xray"></a> [enable\_xray](#input\_enable\_xray) | Enable X-Ray tracing | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, staging, prod) | `string` | `"dev"` | no |
+| <a name="input_evaluation_criteria"></a> [evaluation\_criteria](#input\_evaluation\_criteria) | Evaluation criteria as JSON | `map(string)` | `{}` | no |
+| <a name="input_evaluation_prompt"></a> [evaluation\_prompt](#input\_evaluation\_prompt) | Prompt for agent evaluator | `string` | `"Evaluate the agent's response for correctness and relevance."` | no |
+| <a name="input_evaluation_type"></a> [evaluation\_type](#input\_evaluation\_type) | Type of evaluations (TOOL\_CALL, REASONING, RESPONSE, or ALL) | `string` | `"TOOL_CALL"` | no |
+| <a name="input_evaluator_model_id"></a> [evaluator\_model\_id](#input\_evaluator\_model\_id) | Model ID for evaluator | `string` | `"anthropic.claude-sonnet-4-5"` | no |
+| <a name="input_evaluator_role_arn"></a> [evaluator\_role\_arn](#input\_evaluator\_role\_arn) | IAM role ARN for evaluator | `string` | `""` | no |
+| <a name="input_gateway_name"></a> [gateway\_name](#input\_gateway\_name) | Name for the gateway | `string` | `""` | no |
+| <a name="input_gateway_role_arn"></a> [gateway\_role\_arn](#input\_gateway\_role\_arn) | IAM role ARN for the gateway (if not provided, one will be created) | `string` | `""` | no |
+| <a name="input_gateway_search_type"></a> [gateway\_search\_type](#input\_gateway\_search\_type) | Search type for gateway (SEMANTIC, HYBRID) | `string` | `"HYBRID"` | no |
+| <a name="input_guardrail_blocked_input_messaging"></a> [guardrail\_blocked\_input\_messaging](#input\_guardrail\_blocked\_input\_messaging) | Message to return when input is blocked by guardrail | `string` | `"I'm sorry, I cannot process this request due to safety policies."` | no |
+| <a name="input_guardrail_blocked_outputs_messaging"></a> [guardrail\_blocked\_outputs\_messaging](#input\_guardrail\_blocked\_outputs\_messaging) | Message to return when output is blocked by guardrail | `string` | `"I'm sorry, I cannot provide a response due to safety policies."` | no |
+| <a name="input_guardrail_description"></a> [guardrail\_description](#input\_guardrail\_description) | Description of the guardrail | `string` | `"AgentCore Bedrock Guardrail"` | no |
+| <a name="input_guardrail_filters"></a> [guardrail\_filters](#input\_guardrail\_filters) | Content filters for the guardrail | <pre>list(object({<br/>    type            = string # HATE, INSULT, SEXUAL, VIOLENCE, MISCONDUCT, PROMPT_ATTACK<br/>    input_strength  = string # NONE, LOW, MEDIUM, HIGH<br/>    output_strength = string # NONE, LOW, MEDIUM, HIGH<br/>  }))</pre> | <pre>[<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "HIGH",<br/>    "type": "HATE"<br/>  },<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "HIGH",<br/>    "type": "INSULT"<br/>  },<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "HIGH",<br/>    "type": "SEXUAL"<br/>  },<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "HIGH",<br/>    "type": "VIOLENCE"<br/>  },<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "HIGH",<br/>    "type": "MISCONDUCT"<br/>  },<br/>  {<br/>    "input_strength": "HIGH",<br/>    "output_strength": "NONE",<br/>    "type": "PROMPT_ATTACK"<br/>  }<br/>]</pre> | no |
+| <a name="input_guardrail_name"></a> [guardrail\_name](#input\_guardrail\_name) | Name of the guardrail | `string` | `""` | no |
+| <a name="input_guardrail_sensitive_info_filters"></a> [guardrail\_sensitive\_info\_filters](#input\_guardrail\_sensitive\_info\_filters) | Sensitive information filters (PII) | <pre>list(object({<br/>    type   = string # EMAIL, ADDRESS, PHONE, etc.<br/>    action = string # BLOCK, ANONYMIZE<br/>  }))</pre> | `[]` | no |
+| <a name="input_inference_profile_description"></a> [inference\_profile\_description](#input\_inference\_profile\_description) | Optional description for the inference profile | `string` | `""` | no |
+| <a name="input_inference_profile_model_source_arn"></a> [inference\_profile\_model\_source\_arn](#input\_inference\_profile\_model\_source\_arn) | Model source ARN (foundation model ARN or system-defined inference profile ARN) | `string` | `""` | no |
+| <a name="input_inference_profile_name"></a> [inference\_profile\_name](#input\_inference\_profile\_name) | Name for the Bedrock application inference profile | `string` | `""` | no |
+| <a name="input_inference_profile_tags"></a> [inference\_profile\_tags](#input\_inference\_profile\_tags) | Tags to apply to the inference profile | `map(string)` | `{}` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN for encryption | `string` | `""` | no |
+| <a name="input_lambda_architecture"></a> [lambda\_architecture](#input\_lambda\_architecture) | Architecture for agent runtime Lambda (x86\_64, arm64) | `string` | `"x86_64"` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | CloudWatch log retention in days | `number` | `30` | no |
+| <a name="input_mcp_targets"></a> [mcp\_targets](#input\_mcp\_targets) | MCP targets configuration. Use alias ARNs for version pinning and rollback capability. Recommended: use module.mcp\_servers.mcp\_targets output. | <pre>map(object({<br/>    name        = string<br/>    lambda_arn  = string           # Should be alias ARN (arn:...:function:name:alias)<br/>    version     = optional(string) # Lambda version number for audit trail<br/>    description = optional(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_memory_type"></a> [memory\_type](#input\_memory\_type) | Type of memory (SHORT\_TERM, LONG\_TERM, or BOTH) | `string` | `"BOTH"` | no |
+| <a name="input_oauth_return_urls"></a> [oauth\_return\_urls](#input\_oauth\_return\_urls) | OAuth2 return URLs for workload identity | `list(string)` | `[]` | no |
+| <a name="input_oidc_authorization_endpoint"></a> [oidc\_authorization\_endpoint](#input\_oidc\_authorization\_endpoint) | Override OIDC authorization endpoint (discovers if empty) | `string` | `""` | no |
+| <a name="input_oidc_client_id"></a> [oidc\_client\_id](#input\_oidc\_client\_id) | OIDC Client ID | `string` | `""` | no |
+| <a name="input_oidc_client_secret_arn"></a> [oidc\_client\_secret\_arn](#input\_oidc\_client\_secret\_arn) | Secrets Manager ARN for OIDC Client Secret | `string` | `""` | no |
+| <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | OIDC Issuer URL | `string` | `""` | no |
+| <a name="input_oidc_token_endpoint"></a> [oidc\_token\_endpoint](#input\_oidc\_token\_endpoint) | Override OIDC token endpoint (discovers if empty) | `string` | `""` | no |
+| <a name="input_owner"></a> [owner](#input\_owner) | Owner identifier for resource tagging (team name, individual, or app ID). Applied as the Owner canonical tag. Defaults to app\_id (or agent\_name) when empty. | `string` | `""` | no |
+| <a name="input_policy_engine_role_arn"></a> [policy\_engine\_role\_arn](#input\_policy\_engine\_role\_arn) | IAM role ARN for policy engine | `string` | `""` | no |
+| <a name="input_policy_engine_schema"></a> [policy\_engine\_schema](#input\_policy\_engine\_schema) | Cedar schema definition for policy engine | `string` | `""` | no |
+| <a name="input_proxy_reserved_concurrency"></a> [proxy\_reserved\_concurrency](#input\_proxy\_reserved\_concurrency) | Reserved concurrent executions for the BFF proxy Lambda | `number` | `10` | no |
+| <a name="input_python_version"></a> [python\_version](#input\_python\_version) | Python version for packaging | `string` | `"3.12"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Default AWS region | `string` | `"us-east-1"` | no |
+| <a name="input_runtime_config"></a> [runtime\_config](#input\_runtime\_config) | Runtime configuration as JSON | `map(any)` | `{}` | no |
+| <a name="input_runtime_entry_file"></a> [runtime\_entry\_file](#input\_runtime\_entry\_file) | Entry point file for agent runtime | `string` | `"runtime.py"` | no |
+| <a name="input_runtime_inline_policies"></a> [runtime\_inline\_policies](#input\_runtime\_inline\_policies) | Inline policies to attach to runtime role | `map(string)` | `{}` | no |
+| <a name="input_runtime_policy_arns"></a> [runtime\_policy\_arns](#input\_runtime\_policy\_arns) | Additional IAM policy ARNs to attach to runtime role | `list(string)` | `[]` | no |
+| <a name="input_runtime_reserved_concurrency"></a> [runtime\_reserved\_concurrency](#input\_runtime\_reserved\_concurrency) | Reserved concurrent executions for the agent runtime Lambda | `number` | `10` | no |
+| <a name="input_runtime_role_arn"></a> [runtime\_role\_arn](#input\_runtime\_role\_arn) | IAM role ARN for agent runtime | `string` | `""` | no |
+| <a name="input_runtime_source_path"></a> [runtime\_source\_path](#input\_runtime\_source\_path) | Path to agent source code directory | `string` | `"./agent-code"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to all resources. Canonical tags (AppID, Environment, AgentName, ManagedBy, Owner) are always merged by the root module; values here supplement or override non-canonical keys only. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_agentcore_bff_api_url"></a> [agentcore\_bff\_api\_url](#output\_agentcore\_bff\_api\_url) | BFF API URL |
+| <a name="output_agentcore_bff_authorizer_id"></a> [agentcore\_bff\_authorizer\_id](#output\_agentcore\_bff\_authorizer\_id) | Authorizer ID |
+| <a name="output_agentcore_bff_rest_api_id"></a> [agentcore\_bff\_rest\_api\_id](#output\_agentcore\_bff\_rest\_api\_id) | REST API ID |
+| <a name="output_agentcore_bff_session_table_name"></a> [agentcore\_bff\_session\_table\_name](#output\_agentcore\_bff\_session\_table\_name) | DynamoDB Session Table |
+| <a name="output_agentcore_bff_spa_url"></a> [agentcore\_bff\_spa\_url](#output\_agentcore\_bff\_spa\_url) | SPA URL |
+| <a name="output_agentcore_runtime_arn"></a> [agentcore\_runtime\_arn](#output\_agentcore\_runtime\_arn) | AgentCore runtime ARN |

--- a/terraform/scripts/generate_mcp_openapi.py
+++ b/terraform/scripts/generate_mcp_openapi.py
@@ -1,0 +1,160 @@
+import os
+import ast
+import json
+import glob
+from typing import Dict, Any, List
+
+def parse_tools_from_file(file_path: str) -> Dict[str, Any]:
+    """
+    Parses the TOOLS dictionary from a Python file using AST.
+    Safely extracts description and parameters, ignoring function references.
+    """
+    with open(file_path, 'r') as f:
+        tree = ast.parse(f.read())
+    
+    tools = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == 'TOOLS':
+                    if isinstance(node.value, ast.Dict):
+                        for key, value in zip(node.value.keys, node.value.values):
+                            if isinstance(key, ast.Constant):
+                                tool_name = key.value
+                                tool_info = {}
+                                if isinstance(value, ast.Dict):
+                                    for t_key, t_value in zip(value.keys, value.values):
+                                        if isinstance(t_key, ast.Constant):
+                                            if t_key.value in ['description', 'parameters']:
+                                                # Use ast.literal_eval for these safe values
+                                                tool_info[t_key.value] = ast.literal_eval(t_value)
+                                tools[tool_name] = tool_info
+    return tools
+
+def build_openapi_spec(all_tools: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Builds an OpenAPI 3.1.0 specification from the collected tools.
+    """
+    spec = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "AgentCore MCP Tools API",
+            "version": "1.0.0",
+            "description": "Automatically generated OpenAPI spec from MCP tools registry.",
+        },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "ToolResponse": {
+                    "type": "object",
+                    "properties": {
+                        "success": {"type": "boolean"},
+                        "result": {"type": "object"},
+                        "error": {"type": "string"}
+                    }
+                }
+            }
+        },
+        "tags": []
+    }
+
+    for server_name, tools in all_tools.items():
+        spec["tags"].append({
+            "name": server_name,
+            "description": f"Tools from {server_name} MCP server"
+        })
+        
+        for tool_name, info in tools.items():
+            path = f"/tools/{server_name}/{tool_name}"
+            description = info.get('description', '')
+            parameters = info.get('parameters', {})
+            
+            properties = {}
+            required = []
+            for param_name, param_desc in parameters.items():
+                properties[param_name] = {
+                    "type": "string",
+                    "description": param_desc
+                }
+                if 'required' in param_desc.lower():
+                    required.append(param_name)
+            
+            operation = {
+                "tags": [server_name],
+                "summary": description,
+                "operationId": f"{server_name}_{tool_name}",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": properties,
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful tool execution",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ToolResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            
+            if required:
+                operation["requestBody"]["content"]["application/json"]["schema"]["required"] = required
+            
+            spec["paths"][path] = {"post": operation}
+
+    return spec
+
+def main():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+    mcp_servers_dir = os.path.join(repo_root, 'examples/mcp-servers')
+    output_path = os.path.join(repo_root, 'docs/api/mcp-tools-v1.openapi.json')
+    
+    all_tools = {}
+    
+    # Find all handler.py and server.py files
+    search_patterns = [
+        os.path.join(mcp_servers_dir, '*/handler.py'),
+        os.path.join(mcp_servers_dir, '*/server.py')
+    ]
+    
+    files = []
+    for pattern in search_patterns:
+        files.extend(glob.glob(pattern))
+    
+    for file_path in files:
+        server_name = os.path.basename(os.path.dirname(file_path))
+        if server_name in ['scripts', 'terraform']:
+            continue
+            
+        print(f"Processing {server_name} from {file_path}...")
+        tools = parse_tools_from_file(file_path)
+        if tools:
+            all_tools[server_name] = tools
+            print(f"  Found {len(tools)} tools.")
+        else:
+            print(f"  No TOOLS dictionary found.")
+            
+    if not all_tools:
+        print("No tools found. Check the search patterns and file contents.")
+        return
+        
+    spec = build_openapi_spec(all_tools)
+    
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w') as f:
+        json.dump(spec, f, indent=2)
+        
+    print(f"Successfully generated OpenAPI spec at {output_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds automatic OpenAPI 3.1.0 generation from the MCP tools registry. It includes a Python script that parses the tool handlers via AST and a new Makefile target to update the spec file at `docs/api/mcp-tools-v1.openapi.json`. Mark Issue #33 as closed.