### PR TITLE
feat(bff): persist proxy audit logs to S3/Athena (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ graph TD
 | `agentcore-tools` | Code Interpreter, Browser | Python sandbox (PUBLIC/SANDBOX/VPC modes), Web browser with optional session recording to S3 | `enable_code_interpreter`, `enable_browser`, `enable_browser_recording` |
 | `agentcore-runtime` | Runtime, Memory, Packaging | Agent execution runtime, S3 deployment artifacts bucket, OCDS two-stage build, short-term and long-term memory, application inference profiles | `enable_runtime`, `enable_memory`, `enable_packaging`, `enable_inference_profile` |
 | `agentcore-governance` | Policy Engine, Guardrails, Evaluations | Cedar policy enforcement, Bedrock Guardrails (content/PII filters), model-based evaluation (TOOL_CALL/REASONING/RESPONSE) | `enable_policy_engine`, `enable_guardrails`, `enable_evaluations` |
-| `agentcore-bff` | Token Handler, SPA Hosting, Streaming Proxy | API Gateway REST, Lambda Authorizer, OIDC Handler Lambda, DynamoDB session store, CloudFront distribution, SigV4 streaming proxy (15-min timeout) | `enable_bff` |
+| `agentcore-bff` | Token Handler, SPA Hosting, Streaming Proxy | API Gateway REST, Lambda Authorizer, OIDC Handler Lambda, DynamoDB session store, CloudFront distribution, SigV4 streaming proxy (15-min timeout), optional S3 shadow audit logs with Athena/Glue query metadata | `enable_bff`, `enable_bff_audit_log_persistence` |
 
 ---
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -161,14 +161,15 @@ locals {
 module "agentcore_bff" {
   source = "./modules/agentcore-bff"
 
-  enable_bff         = var.enable_bff
-  agent_name         = var.agent_name
-  app_id             = local.app_id
-  region             = local.bff_region
-  agentcore_region   = local.agentcore_region
-  environment        = var.environment
-  tags               = local.canonical_tags
-  log_retention_days = var.log_retention_days
+  enable_bff                   = var.enable_bff
+  agent_name                   = var.agent_name
+  app_id                       = local.app_id
+  region                       = local.bff_region
+  agentcore_region             = local.agentcore_region
+  environment                  = var.environment
+  tags                         = local.canonical_tags
+  log_retention_days           = var.log_retention_days
+  enable_audit_log_persistence = var.enable_bff_audit_log_persistence
 
   # Auth Configuration
 

--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -26,6 +26,10 @@ module "agentcore_bff" {
   oidc_client_id         = var.oidc_client_id
   oidc_issuer            = "https://login.microsoftonline.com/..."
   oidc_client_secret_arn = "arn:aws:secretsmanager:..."
+
+  # Optional compliance feature (Issue #30)
+  logging_bucket_id             = module.agentcore_foundation.access_logs_bucket_id
+  enable_audit_log_persistence  = true
 }
 ```
 
@@ -39,6 +43,24 @@ module "agentcore_bff" {
 The proxy streams `application/x-ndjson` where each line is a JSON object:
 - `{"type":"meta","sessionId":"..."}`
 - `{"type":"delta","delta":"text chunk"}`
+
+## Audit Log Persistence (Issue #30)
+
+When `enable_audit_log_persistence = true` and `logging_bucket_id` is set, the proxy writes a per-request "shadow JSON" audit record to S3 under:
+
+- `audit/bff-proxy/events/{app_id}/{tenant_id}/year=YYYY/month=MM/day=DD/*.json`
+
+The module also provisions:
+
+- a Glue catalog database/table for the JSON records
+- an Athena workgroup with SSE-S3 query result encryption
+
+Useful outputs:
+
+- `audit_logs_s3_prefix`
+- `audit_logs_athena_database`
+- `audit_logs_athena_table`
+- `audit_logs_athena_workgroup`
 
 ## Known Failure Modes (Rule 16)
 

--- a/terraform/modules/agentcore-bff/audit_logs.tf
+++ b/terraform/modules/agentcore-bff/audit_logs.tf
@@ -1,0 +1,202 @@
+resource "aws_glue_catalog_database" "bff_audit_logs" {
+  count = local.audit_logs_enabled ? 1 : 0
+  name  = local.audit_logs_athena_database
+
+  description = "Query catalog for BFF proxy audit shadow JSON logs (${var.agent_name}/${var.environment})"
+}
+
+resource "aws_glue_catalog_table" "bff_audit_logs" {
+  count         = local.audit_logs_enabled ? 1 : 0
+  name          = local.audit_logs_athena_table
+  database_name = aws_glue_catalog_database.bff_audit_logs[0].name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL             = "TRUE"
+    classification       = "json"
+    "projection.enabled" = "false"
+    "typeOfData"         = "file"
+    "compressionType"    = "none"
+  }
+
+  storage_descriptor {
+    location      = "s3://${var.logging_bucket_id}/${local.audit_logs_events_prefix}"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name                  = "json"
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+      parameters = {
+        "ignore.malformed.json" = "true"
+      }
+    }
+
+    columns {
+      name = "record_type"
+      type = "string"
+    }
+
+    columns {
+      name = "recorded_at"
+      type = "string"
+    }
+
+    columns {
+      name = "started_at"
+      type = "string"
+    }
+
+    columns {
+      name = "completed_at"
+      type = "string"
+    }
+
+    columns {
+      name = "duration_ms"
+      type = "bigint"
+    }
+
+    columns {
+      name = "request_id"
+      type = "string"
+    }
+
+    columns {
+      name = "agent_name"
+      type = "string"
+    }
+
+    columns {
+      name = "environment"
+      type = "string"
+    }
+
+    columns {
+      name = "app_id"
+      type = "string"
+    }
+
+    columns {
+      name = "tenant_id"
+      type = "string"
+    }
+
+    columns {
+      name = "session_id_requested"
+      type = "string"
+    }
+
+    columns {
+      name = "session_id_authorized"
+      type = "string"
+    }
+
+    columns {
+      name = "runtime_session_id"
+      type = "string"
+    }
+
+    columns {
+      name = "http_method"
+      type = "string"
+    }
+
+    columns {
+      name = "resource_path"
+      type = "string"
+    }
+
+    columns {
+      name = "source_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "user_agent"
+      type = "string"
+    }
+
+    columns {
+      name = "status_code"
+      type = "int"
+    }
+
+    columns {
+      name = "outcome"
+      type = "string"
+    }
+
+    columns {
+      name = "error_message"
+      type = "string"
+    }
+
+    columns {
+      name = "request_prompt_chars"
+      type = "int"
+    }
+
+    columns {
+      name = "request_prompt_sha256"
+      type = "string"
+    }
+
+    columns {
+      name = "request_prompt_preview"
+      type = "string"
+    }
+
+    columns {
+      name = "request_prompt_preview_truncated"
+      type = "boolean"
+    }
+
+    columns {
+      name = "response_delta_chunks"
+      type = "int"
+    }
+
+    columns {
+      name = "response_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "response_sha256"
+      type = "string"
+    }
+
+    columns {
+      name = "response_preview"
+      type = "string"
+    }
+
+    columns {
+      name = "response_preview_truncated"
+      type = "boolean"
+    }
+  }
+}
+
+resource "aws_athena_workgroup" "bff_audit_logs" {
+  count = local.audit_logs_enabled ? 1 : 0
+  name  = local.audit_logs_athena_workgroup
+
+  force_destroy = false
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${var.logging_bucket_id}/${local.audit_logs_athena_results_prefix}"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+
+  tags = var.tags
+}

--- a/terraform/modules/agentcore-bff/iam.tf
+++ b/terraform/modules/agentcore-bff/iam.tf
@@ -143,6 +143,15 @@ resource "aws_iam_role_policy" "proxy" {
           Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/*"
         }
       ],
+      local.audit_logs_enabled ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:PutObject"
+          ]
+          Resource = "arn:aws:s3:::${var.logging_bucket_id}/${local.audit_logs_events_prefix}*"
+        }
+      ] : [],
       # Senior Move: Dynamic Session Policies
       var.agentcore_runtime_role_arn != "" ? [
         {

--- a/terraform/modules/agentcore-bff/lambda.tf
+++ b/terraform/modules/agentcore-bff/lambda.tf
@@ -110,6 +110,11 @@ resource "aws_lambda_function" "proxy" {
       AGENTCORE_RUNTIME_ARN      = var.agentcore_runtime_arn
       AGENTCORE_REGION           = local.agentcore_region
       AGENTCORE_RUNTIME_ROLE_ARN = var.agentcore_runtime_role_arn
+      AGENT_NAME                 = var.agent_name
+      ENVIRONMENT                = var.environment
+      AUDIT_LOGS_ENABLED         = tostring(local.audit_logs_enabled)
+      AUDIT_LOGS_BUCKET          = local.audit_logs_enabled ? var.logging_bucket_id : ""
+      AUDIT_LOGS_PREFIX          = local.audit_logs_events_prefix
     }
   }
 }

--- a/terraform/modules/agentcore-bff/locals.tf
+++ b/terraform/modules/agentcore-bff/locals.tf
@@ -1,3 +1,14 @@
 locals {
   agentcore_region = var.agentcore_region != "" ? var.agentcore_region : var.region
+
+  audit_logs_enabled = var.enable_bff && var.enable_audit_log_persistence && trimspace(var.logging_bucket_id) != ""
+  audit_logs_prefix  = "audit/bff-proxy"
+
+  audit_logs_events_prefix         = "${local.audit_logs_prefix}/events/"
+  audit_logs_athena_results_prefix = "${local.audit_logs_prefix}/athena-results/"
+
+  athena_name_suffix          = replace(lower("${var.agent_name}_${var.environment}"), "-", "_")
+  audit_logs_athena_database  = "agentcore_bff_audit_${local.athena_name_suffix}"
+  audit_logs_athena_table     = "proxy_shadow_json"
+  audit_logs_athena_workgroup = "agentcore-bff-audit-${var.agent_name}-${var.environment}"
 }

--- a/terraform/modules/agentcore-bff/outputs.tf
+++ b/terraform/modules/agentcore-bff/outputs.tf
@@ -22,3 +22,23 @@ output "authorizer_id" {
   description = "ID of the Lambda Authorizer"
   value       = var.enable_bff ? aws_api_gateway_authorizer.token_handler[0].id : ""
 }
+
+output "audit_logs_s3_prefix" {
+  description = "S3 prefix for BFF proxy audit shadow JSON logs"
+  value       = local.audit_logs_enabled ? local.audit_logs_events_prefix : ""
+}
+
+output "audit_logs_athena_database" {
+  description = "Glue/Athena database name for BFF proxy audit logs"
+  value       = local.audit_logs_enabled ? aws_glue_catalog_database.bff_audit_logs[0].name : ""
+}
+
+output "audit_logs_athena_table" {
+  description = "Glue/Athena table name for BFF proxy audit logs"
+  value       = local.audit_logs_enabled ? aws_glue_catalog_table.bff_audit_logs[0].name : ""
+}
+
+output "audit_logs_athena_workgroup" {
+  description = "Athena workgroup name for BFF proxy audit log queries"
+  value       = local.audit_logs_enabled ? aws_athena_workgroup.bff_audit_logs[0].name : ""
+}

--- a/terraform/modules/agentcore-bff/src/proxy.js
+++ b/terraform/modules/agentcore-bff/src/proxy.js
@@ -1,8 +1,10 @@
 /* global awslambda */
+const crypto = require("crypto");
 const { SignatureV4 } = require("@smithy/signature-v4");
 const { Sha256 } = require("@aws-crypto/sha256-js");
 const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 const { STSClient, AssumeRoleCommand } = require("@aws-sdk/client-sts");
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const https = require("https");
 const { URL } = require("url");
 
@@ -11,7 +13,19 @@ const AGENTCORE_REGION = process.env.AGENTCORE_REGION || process.env.AWS_REGION;
 const AGENTCORE_RUNTIME_ROLE_ARN = process.env.AGENTCORE_RUNTIME_ROLE_ARN;
 const AGENTCORE_SERVICE = "bedrock-agentcore";
 
+const AGENT_NAME = process.env.AGENT_NAME || "";
+const ENVIRONMENT = process.env.ENVIRONMENT || "";
+const AUDIT_LOGS_ENABLED = process.env.AUDIT_LOGS_ENABLED === "true";
+const AUDIT_LOGS_BUCKET = process.env.AUDIT_LOGS_BUCKET || "";
+const AUDIT_LOGS_PREFIX = process.env.AUDIT_LOGS_PREFIX || "audit/bff-proxy/events/";
+const AUDIT_PREVIEW_MAX_CHARS = 16384;
+const AUDIT_PROMPT_PREVIEW_MAX_CHARS = 4096;
+
 const stsClient = new STSClient({ region: AGENTCORE_REGION });
+const s3Client =
+  AUDIT_LOGS_ENABLED && AUDIT_LOGS_BUCKET
+    ? new S3Client({ region: process.env.AWS_REGION || AGENTCORE_REGION })
+    : null;
 
 function writeError(responseStream, statusCode, message) {
   const s = awslambda.HttpResponseStream.from(responseStream, {
@@ -19,6 +33,144 @@ function writeError(responseStream, statusCode, message) {
     headers: { "content-type": "application/json" },
   });
   s.end(JSON.stringify({ error: message }));
+}
+
+function safeString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(value || "", "utf8").digest("hex");
+}
+
+function truncateText(text, maxChars) {
+  const value = safeString(text);
+  if (value.length <= maxChars) {
+    return { value, truncated: false };
+  }
+  return { value: value.slice(0, maxChars), truncated: true };
+}
+
+function sanitizeKeySegment(value) {
+  const raw = safeString(value).trim();
+  if (!raw) return "unknown";
+  const sanitized = raw.replace(/[^a-zA-Z0-9._=-]/g, "_");
+  return sanitized || "unknown";
+}
+
+function normalizePrefix(prefix) {
+  const raw = safeString(prefix).replace(/^\/+/, "");
+  return raw.endsWith("/") ? raw : `${raw}/`;
+}
+
+function createAuditRecord(event) {
+  const requestContext = event.requestContext || {};
+  const httpContext = requestContext.http || {};
+  const identity = requestContext.identity || {};
+  const headers = event.headers || {};
+  const startedAt = new Date().toISOString();
+
+  return {
+    record_type: "bff_proxy_audit_shadow_json_v1",
+    recorded_at: startedAt,
+    started_at: startedAt,
+    completed_at: null,
+    duration_ms: null,
+    request_id: requestContext.requestId || crypto.randomUUID(),
+    agent_name: AGENT_NAME || null,
+    environment: ENVIRONMENT || null,
+    app_id: null,
+    tenant_id: null,
+    session_id_requested: null,
+    session_id_authorized: null,
+    runtime_session_id: null,
+    http_method: httpContext.method || requestContext.httpMethod || null,
+    resource_path: event.rawPath || requestContext.resourcePath || requestContext.path || null,
+    source_ip: httpContext.sourceIp || identity.sourceIp || null,
+    user_agent: safeString(headers["user-agent"] || headers["User-Agent"]) || null,
+    status_code: null,
+    outcome: "started",
+    error_message: null,
+    request_prompt_chars: 0,
+    request_prompt_sha256: null,
+    request_prompt_preview: null,
+    request_prompt_preview_truncated: false,
+    response_delta_chunks: 0,
+    response_bytes: 0,
+    response_sha256: null,
+    response_preview: "",
+    response_preview_truncated: false,
+    _responseHasher: crypto.createHash("sha256"),
+  };
+}
+
+function finalizeAuditRecord(auditRecord) {
+  if (!auditRecord) return null;
+
+  auditRecord.completed_at = new Date().toISOString();
+  const started = Date.parse(auditRecord.started_at);
+  const completed = Date.parse(auditRecord.completed_at);
+  if (!Number.isNaN(started) && !Number.isNaN(completed)) {
+    auditRecord.duration_ms = Math.max(0, completed - started);
+  }
+
+  if (auditRecord._responseHasher) {
+    auditRecord.response_sha256 = auditRecord._responseHasher.digest("hex");
+    delete auditRecord._responseHasher;
+  }
+
+  if (!auditRecord.outcome || auditRecord.outcome === "started") {
+    auditRecord.outcome = auditRecord.status_code && auditRecord.status_code < 400 ? "success" : "error";
+  }
+
+  if (auditRecord.response_preview === "") {
+    auditRecord.response_preview = null;
+  }
+
+  return auditRecord;
+}
+
+function buildAuditLogKey(auditRecord) {
+  const ts = auditRecord.completed_at || auditRecord.recorded_at || new Date().toISOString();
+  const date = new Date(ts);
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const prefix = normalizePrefix(AUDIT_LOGS_PREFIX);
+
+  return `${prefix}${sanitizeKeySegment(auditRecord.app_id)}/${sanitizeKeySegment(auditRecord.tenant_id)}/year=${year}/month=${month}/day=${day}/${sanitizeKeySegment(auditRecord.request_id)}.json`;
+}
+
+async function persistAuditLog(auditRecord) {
+  if (!AUDIT_LOGS_ENABLED || !AUDIT_LOGS_BUCKET || !s3Client || !auditRecord) return;
+
+  try {
+    const body = JSON.stringify(auditRecord) + "\n";
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: AUDIT_LOGS_BUCKET,
+        Key: buildAuditLogKey(auditRecord),
+        Body: body,
+        ContentType: "application/json",
+        ServerSideEncryption: "AES256",
+      }),
+    );
+  } catch (err) {
+    // Audit persistence is best-effort to avoid dropping user responses on transient S3 failures.
+    console.error(`Audit log persist failed: ${err && err.message ? err.message : String(err)}`);
+  }
+}
+
+function appendResponsePreview(auditRecord, text) {
+  if (!auditRecord || !text || auditRecord.response_preview_truncated) return;
+  const current = auditRecord.response_preview || "";
+  const next = current + text;
+  if (next.length <= AUDIT_PREVIEW_MAX_CHARS) {
+    auditRecord.response_preview = next;
+    return;
+  }
+  auditRecord.response_preview = next.slice(0, AUDIT_PREVIEW_MAX_CHARS);
+  auditRecord.response_preview_truncated = true;
 }
 
 async function signRequest(method, url, headers, body, credentials) {
@@ -45,7 +197,7 @@ async function signRequest(method, url, headers, body, credentials) {
   return signed;
 }
 
-function sendRequest(signed, body, responseStream, sessionId) {
+function sendRequest(signed, body, responseStream, sessionId, auditRecord) {
   return new Promise((resolve, reject) => {
     const options = {
       method: signed.method,
@@ -56,12 +208,23 @@ function sendRequest(signed, body, responseStream, sessionId) {
 
     const upstream = https.request(options, (res) => {
       const statusCode = res.statusCode || 200;
+      if (auditRecord) {
+        auditRecord.status_code = statusCode;
+      }
+
       if (statusCode >= 400) {
         let errorBody = "";
         res.on("data", (chunk) => {
           errorBody += chunk.toString("utf-8");
         });
         res.on("end", () => {
+          if (auditRecord) {
+            auditRecord.outcome = "upstream_error";
+            auditRecord.error_message = errorBody || `Upstream returned status ${statusCode}`;
+            auditRecord._responseHasher.update(errorBody, "utf8");
+            auditRecord.response_bytes += Buffer.byteLength(errorBody, "utf8");
+            appendResponsePreview(auditRecord, errorBody);
+          }
           writeError(responseStream, statusCode, errorBody);
           resolve();
         });
@@ -77,6 +240,9 @@ function sendRequest(signed, body, responseStream, sessionId) {
       if (runtimeSessionId) {
         responseHeaders["x-amzn-bedrock-agentcore-runtime-session-id"] = runtimeSessionId;
       }
+      if (auditRecord && runtimeSessionId) {
+        auditRecord.runtime_session_id = runtimeSessionId;
+      }
 
       const httpStream = awslambda.HttpResponseStream.from(responseStream, {
         statusCode,
@@ -90,27 +256,54 @@ function sendRequest(signed, body, responseStream, sessionId) {
       res.on("data", (chunk) => {
         const text = chunk.toString("utf-8");
         if (!text) return;
+
+        if (auditRecord) {
+          auditRecord.response_delta_chunks += 1;
+          auditRecord.response_bytes += Buffer.byteLength(text, "utf8");
+          auditRecord._responseHasher.update(text, "utf8");
+          appendResponsePreview(auditRecord, text);
+        }
+
         httpStream.write(JSON.stringify({ type: "delta", delta: text }) + "\n");
       });
       res.on("end", () => {
+        if (auditRecord) {
+          auditRecord.outcome = "success";
+        }
         httpStream.end();
         resolve();
       });
     });
 
-    upstream.on("error", (err) => reject(err));
+    upstream.on("error", (err) => {
+      if (auditRecord) {
+        auditRecord.outcome = "transport_error";
+        auditRecord.error_message = err && err.message ? err.message : String(err);
+      }
+      reject(err);
+    });
     upstream.write(body);
     upstream.end();
   });
 }
 
 exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
+  const auditRecord = createAuditRecord(event);
+
   if (!AGENTCORE_RUNTIME_ARN) {
+    auditRecord.status_code = 500;
+    auditRecord.outcome = "config_error";
+    auditRecord.error_message = "Missing AGENTCORE_RUNTIME_ARN";
     writeError(responseStream, 500, "Missing AGENTCORE_RUNTIME_ARN");
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
     return;
   }
   if (!AGENTCORE_REGION) {
+    auditRecord.status_code = 500;
+    auditRecord.outcome = "config_error";
+    auditRecord.error_message = "Missing AGENTCORE_REGION";
     writeError(responseStream, 500, "Missing AGENTCORE_REGION");
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
     return;
   }
 
@@ -120,8 +313,13 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
   const appId = authorizer.app_id;
   const authorizedSessionId = authorizer.session_id;
 
+  auditRecord.app_id = appId || null;
+  auditRecord.tenant_id = tenantId || null;
+  auditRecord.session_id_authorized = authorizedSessionId || null;
+
   let prompt;
   let sessionId;
+
   try {
     const rawBody = event.body
       ? event.isBase64Encoded
@@ -131,19 +329,39 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
     const body = JSON.parse(rawBody);
     prompt = body.prompt;
     sessionId = body.sessionId || "default-session";
+
+    auditRecord.session_id_requested = sessionId;
+    const promptValue = typeof prompt === "string" ? prompt : "";
+    auditRecord.request_prompt_chars = promptValue.length;
+    auditRecord.request_prompt_sha256 = prompt ? sha256Hex(promptValue) : null;
+    const promptPreview = truncateText(promptValue, AUDIT_PROMPT_PREVIEW_MAX_CHARS);
+    auditRecord.request_prompt_preview = promptPreview.value || null;
+    auditRecord.request_prompt_preview_truncated = promptPreview.truncated;
   } catch {
+    auditRecord.status_code = 400;
+    auditRecord.outcome = "invalid_request";
+    auditRecord.error_message = "Invalid JSON";
     writeError(responseStream, 400, "Invalid JSON");
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
     return;
   }
 
   if (!prompt) {
+    auditRecord.status_code = 400;
+    auditRecord.outcome = "invalid_request";
+    auditRecord.error_message = "Missing prompt";
     writeError(responseStream, 400, "Missing prompt");
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
     return;
   }
 
   // Multi-tenancy Isolation Check (Rule 14.1)
   if (authorizedSessionId && sessionId !== authorizedSessionId) {
+    auditRecord.status_code = 403;
+    auditRecord.outcome = "session_isolation_violation";
+    auditRecord.error_message = "Session isolation violation: tenant mismatch";
     writeError(responseStream, 403, "Session isolation violation: tenant mismatch");
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
     return;
   }
 
@@ -187,43 +405,47 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
               Effect: "Allow",
               Action: ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
               Resource: [
-                `arn:aws:s3:::*-deployment-*`,
+                "arn:aws:s3:::*-deployment-*",
                 `arn:aws:s3:::*-memory-*/${appId}/${tenantId}/*`,
-                `arn:aws:s3:::*-memory-*/${appId}/${tenantId}`
-              ]
+                `arn:aws:s3:::*-memory-*/${appId}/${tenantId}`,
+              ],
             },
             {
               Effect: "Allow",
               Action: ["bedrock-agentcore:InvokeAgentRuntime"],
-              Resource: [AGENTCORE_RUNTIME_ARN]
-            }
-          ]
+              Resource: [AGENTCORE_RUNTIME_ARN],
+            },
+          ],
         };
 
         const assumeRoleCmd = new AssumeRoleCommand({
           RoleArn: AGENTCORE_RUNTIME_ROLE_ARN,
           RoleSessionName: `AgentCore-${appId}-${tenantId}`,
           Policy: JSON.stringify(sessionPolicy),
-          DurationSeconds: 900
+          DurationSeconds: 900,
         });
 
         const assumed = await stsClient.send(assumeRoleCmd);
         credentials = {
           accessKeyId: assumed.Credentials.AccessKeyId,
           secretAccessKey: assumed.Credentials.SecretAccessKey,
-          sessionToken: assumed.Credentials.SessionToken
+          sessionToken: assumed.Credentials.SessionToken,
         };
       } catch (err) {
         console.error(`AssumeRole failed: ${err}`);
-        // Fallback to default if assumption fails, or throw if strict
         throw new Error(`Identity isolation failed: ${err.message}`);
       }
     }
 
     const signed = await signRequest("POST", url.toString(), headers, payload, credentials);
-    await sendRequest(signed, payload, responseStream, sessionId);
+    await sendRequest(signed, payload, responseStream, sessionId, auditRecord);
   } catch (err) {
+    auditRecord.status_code = auditRecord.status_code || 500;
+    auditRecord.outcome = auditRecord.outcome === "success" ? "error_after_stream" : "error";
+    auditRecord.error_message = err && err.message ? err.message : String(err);
     writeError(responseStream, 500, String(err));
+  } finally {
+    await persistAuditLog(finalizeAuditRecord(auditRecord));
   }
 });
 
@@ -231,3 +453,5 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream) => {
 exports._writeError = writeError;
 exports._signRequest = signRequest;
 exports._sendRequest = sendRequest;
+exports._createAuditRecord = createAuditRecord;
+exports._finalizeAuditRecord = finalizeAuditRecord;

--- a/terraform/modules/agentcore-bff/variables.tf
+++ b/terraform/modules/agentcore-bff/variables.tf
@@ -56,6 +56,12 @@ variable "logging_bucket_id" {
   default     = ""
 }
 
+variable "enable_audit_log_persistence" {
+  description = "Persist BFF proxy audit shadow JSON to S3 and provision Athena/Glue metadata"
+  type        = bool
+  default     = false
+}
+
 variable "oidc_issuer" {
   description = "OIDC Issuer URL (e.g., https://login.microsoftonline.com/...)"
   type        = string

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -23,6 +23,26 @@ output "agentcore_bff_authorizer_id" {
   value       = module.agentcore_bff.authorizer_id
 }
 
+output "agentcore_bff_audit_logs_s3_prefix" {
+  description = "S3 prefix for BFF proxy audit shadow JSON logs"
+  value       = module.agentcore_bff.audit_logs_s3_prefix
+}
+
+output "agentcore_bff_audit_logs_athena_database" {
+  description = "Athena/Glue database for BFF proxy audit logs"
+  value       = module.agentcore_bff.audit_logs_athena_database
+}
+
+output "agentcore_bff_audit_logs_athena_table" {
+  description = "Athena/Glue table for BFF proxy audit logs"
+  value       = module.agentcore_bff.audit_logs_athena_table
+}
+
+output "agentcore_bff_audit_logs_athena_workgroup" {
+  description = "Athena workgroup for BFF proxy audit logs"
+  value       = module.agentcore_bff.audit_logs_athena_workgroup
+}
+
 output "agentcore_runtime_arn" {
   description = "AgentCore runtime ARN"
   value       = module.agentcore_runtime.runtime_arn

--- a/terraform/tests/validation/test_bff_audit_log_persistence.py
+++ b/terraform/tests/validation/test_bff_audit_log_persistence.py
@@ -1,0 +1,88 @@
+import sys
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_bff_module_audit_resources():
+    print("[Audit Test 1] Verifying BFF audit Glue/Athena resources...")
+    content = _read("terraform/modules/agentcore-bff/audit_logs.tf")
+
+    required = [
+        'resource "aws_glue_catalog_database" "bff_audit_logs"',
+        'resource "aws_glue_catalog_table" "bff_audit_logs"',
+        'resource "aws_athena_workgroup" "bff_audit_logs"',
+        'serialization_library = "org.openx.data.jsonserde.JsonSerDe"',
+        'encryption_option = "SSE_S3"',
+    ]
+    for needle in required:
+        if needle not in content:
+            raise Exception(f"FAILED: Missing expected audit resource/config: {needle}")
+
+    print("  PASS: Glue/Athena audit resources present and SSE-S3 enforced.")
+
+
+def test_bff_proxy_shadow_s3_write():
+    print("[Audit Test 2] Verifying proxy shadow JSON S3 write path...")
+    content = _read("terraform/modules/agentcore-bff/src/proxy.js")
+
+    required = [
+        "@aws-sdk/client-s3",
+        "PutObjectCommand",
+        "AUDIT_LOGS_ENABLED",
+        "AUDIT_LOGS_BUCKET",
+        "AUDIT_LOGS_PREFIX",
+        "persistAuditLog",
+        "app_id",
+        "tenant_id",
+        "response_preview_truncated",
+        "ServerSideEncryption: \"AES256\"",
+    ]
+    for needle in required:
+        if needle not in content:
+            raise Exception(f"FAILED: Proxy audit persistence missing marker: {needle}")
+
+    if "access_token" in content and "audit" in content:
+        # We intentionally read access_token for upstream auth. Ensure we are not storing it in the audit record.
+        if "access_token:" in content or "accessToken:" in content:
+            raise Exception("FAILED: access token appears to be serialized into proxy structures")
+
+    print("  PASS: Proxy writes shadow audit JSON to S3 without token serialization markers.")
+
+
+def test_bff_proxy_iam_and_env_wiring():
+    print("[Audit Test 3] Verifying proxy IAM and env wiring for audit persistence...")
+    iam_content = _read("terraform/modules/agentcore-bff/iam.tf")
+    lambda_content = _read("terraform/modules/agentcore-bff/lambda.tf")
+    vars_content = _read("terraform/modules/agentcore-bff/variables.tf")
+    root_vars_content = _read("terraform/variables_bff.tf")
+    root_main_content = _read("terraform/main.tf")
+    root_outputs_content = _read("terraform/outputs.tf")
+
+    if '"s3:PutObject"' not in iam_content:
+        raise Exception("FAILED: Proxy IAM policy missing s3:PutObject for audit logs")
+    if "AUDIT_LOGS_BUCKET" not in lambda_content or "AUDIT_LOGS_ENABLED" not in lambda_content:
+        raise Exception("FAILED: Proxy Lambda environment missing audit log variables")
+    if 'variable "enable_audit_log_persistence"' not in vars_content:
+        raise Exception("FAILED: BFF module audit persistence toggle missing")
+    if 'variable "enable_bff_audit_log_persistence"' not in root_vars_content:
+        raise Exception("FAILED: Root BFF audit persistence toggle missing")
+    if "enable_audit_log_persistence = var.enable_bff_audit_log_persistence" not in root_main_content:
+        raise Exception("FAILED: Root main.tf does not pass audit persistence toggle to BFF module")
+    if "agentcore_bff_audit_logs_athena_workgroup" not in root_outputs_content:
+        raise Exception("FAILED: Root outputs missing Athena audit workgroup output")
+
+    print("  PASS: IAM/env/root wiring for BFF audit persistence verified.")
+
+
+if __name__ == "__main__":
+    try:
+        test_bff_module_audit_resources()
+        test_bff_proxy_shadow_s3_write()
+        test_bff_proxy_iam_and_env_wiring()
+        print("\nBFF audit log persistence validation tests PASSED.")
+    except Exception as e:
+        print(f"\nBFF AUDIT LOG PERSISTENCE TEST FAILED: {e}")
+        sys.exit(1)

--- a/terraform/variables_bff.tf
+++ b/terraform/variables_bff.tf
@@ -6,6 +6,12 @@ variable "enable_bff" {
   default     = false
 }
 
+variable "enable_bff_audit_log_persistence" {
+  description = "Persist BFF proxy shadow audit logs to S3 and provision Athena/Glue query resources"
+  type        = bool
+  default     = false
+}
+
 variable "oidc_issuer" {
   description = "OIDC Issuer URL"
   type        = string


### PR DESCRIPTION
## Summary
- persist BFF proxy audit "shadow JSON" records directly to S3 (tenant/app scoped paths)
- provision Glue/Athena metadata (database/table/workgroup) for compliance queries
- expose root/module outputs and add validation coverage for audit persistence wiring

## Scope
- issue #30 (execution issue, workstream e / item e1)

## Validation
- `make preflight-session` (PASS, before commit)
- `node --check terraform/modules/agentcore-bff/src/proxy.js`
- `python3 terraform/tests/validation/test_bff_audit_log_persistence.py`
- `terraform -chdir=terraform fmt -recursive`
- `terraform -chdir=terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false -input=false`
- `terraform -chdir=terraform validate`
- `make preflight-session` (PASS, before push)

## Notes
- audit persistence is opt-in via `enable_bff_audit_log_persistence`
- proxy audit S3 writes are best-effort (logged on failure) to avoid breaking user streaming responses

Closes #30
