### PR TITLE
feat(dx): add reusable frontend component library

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -114,6 +114,21 @@ make generate-openapi
 
 The generated file will be saved to `docs/api/mcp-tools-v1.openapi.json`. This spec can be used by the Web UI to dynamically build tool-calling interfaces or for testing.
 
+#### Frontend Component Library (React + Tailwind, No Bundler)
+
+The SPA template and the integrated example now ship with a reusable frontend component library:
+
+- `templates/agent-project/frontend/components.js`
+- `examples/5-integrated/frontend/components.js`
+
+The library is intentionally static-hosting friendly:
+
+- React is loaded via browser ES modules (no Node build step required)
+- Tailwind is loaded via CDN
+- Components are plain reusable blocks (`AppShell`, `Panel`, `MetricCard`, `Transcript`, `Timeline`, `ToolCatalog`, etc.)
+
+To customize a specialized dashboard, compose panels in `frontend/app.js` and keep shared primitives in `frontend/components.js`. The example app will try to load `docs/api/mcp-tools-v1.openapi.json` so issue `#33` OpenAPI output can drive tool panels.
+
 # Syntax validation
 terraform validate
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ python terraform/scripts/acore_debug.py
 
 The debug TUI (`acore_debug.py`) auto-discovers your deployed infrastructure from `terraform output -json`, then streams CloudWatch logs into a live terminal panel alongside a latency trace that breaks down each request into Gateway, Authorizer, Router, Lambda, and Bedrock segments. Press `r` to trigger a manual reload without leaving the debugger. The tool speaks the OCDS protocol -- when it reloads, it runs an identical targeted apply that respects the two-stage hash boundaries.
 
+### Frontend Component Library (React + Tailwind)
+
+The SPA frontend template now includes a reusable, static-hosting-compatible component library for building specialized agent dashboards without introducing a frontend build pipeline. The library lives in `templates/agent-project/frontend/components.js` and is mirrored in `examples/5-integrated/frontend/components.js`.
+
+- **Runtime model:** Browser-loaded React + Tailwind (ES modules, no bundler required)
+- **Reusable blocks:** App shell, panels, metric cards, transcript, timeline, tool catalog, JSON preview, prompt composer
+- **DX integration:** The example app attempts to load `docs/api/mcp-tools-v1.openapi.json` to populate dashboard tool panels automatically
+
+This keeps the BFF/Token Handler deployment model serverless and static while giving teams a composable UI base for role-specific consoles.
+
 ### Local MCP Development
 
 The `examples/mcp-servers/local-dev/` directory provides a Flask-based MCP server that implements the same protocol your Lambda handlers speak, without requiring an AWS account. Start it with `make dev` from the `examples/mcp-servers/` directory and it binds to `localhost:8080`, serving tool definitions and handling invocations against local data. The development cycle is bidirectional: build and test locally, promote to Lambda when the logic is stable, diagnose production issues locally by pulling real payloads down and replaying them against the Flask server.

--- a/examples/5-integrated/README.md
+++ b/examples/5-integrated/README.md
@@ -86,6 +86,15 @@ Edit `main.tf` to:
 - Change agent capabilities (enable browser, memory, etc.)
 - Modify runtime configuration
 
+### Frontend Dashboard Customization
+
+The example frontend now uses a reusable React/Tailwind component library (no bundler required):
+
+- `frontend/components.js` contains reusable primitives (`AppShell`, `Panel`, `MetricCard`, `Transcript`, `Timeline`, `ToolCatalog`, `JsonPreview`)
+- `frontend/app.js` composes those primitives into an operator dashboard
+
+To build a specialized dashboard, keep shared UI blocks in `frontend/components.js` and swap panel composition/data wiring in `frontend/app.js`. The app will also try to load `docs/api/mcp-tools-v1.openapi.json` to populate a tool catalog panel from generated OpenAPI metadata.
+
 ## Testing
 
 ```bash

--- a/examples/5-integrated/frontend/app.js
+++ b/examples/5-integrated/frontend/app.js
@@ -1,109 +1,436 @@
+import React, { useEffect, useRef, useState } from 'https://esm.sh/react@18.3.1';
+import { createRoot } from 'https://esm.sh/react-dom@18.3.1/client';
+import htm from 'https://esm.sh/htm@3.1.1';
+import {
+  ActionButton,
+  AppShell,
+  AuthCard,
+  COMPONENT_LIBRARY_VERSION,
+  JsonPreview,
+  LibraryList,
+  MetricGrid,
+  Panel,
+  PromptComposer,
+  StatusBadge,
+  Timeline,
+  ToolCatalog,
+  Transcript,
+} from './components.js';
+
+const html = htm.bind(React.createElement);
+
 const API_URL = '/api/chat';
 const AUTH_URL = '/auth/login';
+const OPENAPI_CANDIDATE_URLS = ['/docs/api/mcp-tools-v1.openapi.json', '/mcp-tools-v1.openapi.json'];
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'options', 'head']);
 
-// Check for session cookie (simple check)
-function checkAuth() {
-    if (document.cookie.includes('session_id')) {
-        document.getElementById('status').innerHTML = '<span class="text-green-500">CONNECTED</span>';
-        document.getElementById('chat-form').classList.remove('hidden');
-        document.getElementById('auth-panel').classList.add('hidden');
-    } else {
-        document.getElementById('status').innerHTML = '<span class="text-red-500 blink">UNAUTHORIZED</span>';
-        document.getElementById('chat-form').classList.add('hidden');
-        document.getElementById('auth-panel').classList.remove('hidden');
+function nowStamp() {
+  return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function makeMessage(role, text) {
+  return {
+    id: `${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    role,
+    text,
+    timestamp: nowStamp(),
+  };
+}
+
+function normalizeStreamLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return { type: 'delta', delta: line };
+  }
+}
+
+function extractToolsFromOpenApi(spec) {
+  if (!spec || !spec.paths || typeof spec.paths !== 'object') {
+    return [];
+  }
+
+  const tools = [];
+  for (const [path, methods] of Object.entries(spec.paths)) {
+    if (!methods || typeof methods !== 'object') {
+      continue;
     }
+
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!HTTP_METHODS.has(method)) {
+        continue;
+      }
+
+      if (!operation || typeof operation !== 'object') {
+        continue;
+      }
+
+      tools.push({
+        id: `${method}:${path}`,
+        method: method.toUpperCase(),
+        name: operation.operationId || path,
+        description: operation.summary || operation.description || '',
+      });
+    }
+  }
+
+  return tools.slice(0, 12);
 }
 
-function login() {
-    window.location.href = AUTH_URL;
+function sampleTools() {
+  return [
+    {
+      id: 'tool:s3.list_objects',
+      method: 'MCP',
+      name: 's3.list_objects',
+      description: 'List objects in a tenant-scoped S3 prefix for dashboard exploration.',
+    },
+    {
+      id: 'tool:analytics.run_query',
+      method: 'MCP',
+      name: 'analytics.run_query',
+      description: 'Execute a scoped analytics query and stream results back to the panel.',
+    },
+    {
+      id: 'tool:research.fetch_sources',
+      method: 'MCP',
+      name: 'research.fetch_sources',
+      description: 'Resolve and summarize source documents for deep-research workflows.',
+    },
+  ];
 }
 
-async function sendMessage(e) {
-    e.preventDefault();
-    const input = document.getElementById('prompt');
-    const text = input.value;
-    if (!text) return;
+function inferAuthState() {
+  return document.cookie.includes('session_id') ? 'connected' : 'unauthorized';
+}
 
-    appendLog(`> ${text}`, 'text-green-300');
-    input.value = '';
+function App() {
+  const [authState, setAuthState] = useState(inferAuthState());
+  const [prompt, setPrompt] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [transportStatus, setTransportStatus] = useState('idle');
+  const [messages, setMessages] = useState(() => [
+    makeMessage('system', 'AgentCore frontend component library loaded.'),
+    makeMessage('system', 'Use these React/Tailwind panels to compose specialized dashboards.'),
+  ]);
+  const [events, setEvents] = useState(() => [
+    { id: 'boot', label: 'UI booted', detail: `Component library v${COMPONENT_LIBRARY_VERSION}`, time: nowStamp() },
+  ]);
+  const [toolCatalog, setToolCatalog] = useState(sampleTools());
+  const [toolSource, setToolSource] = useState('Embedded sample catalog');
+  const [toolsLoading, setToolsLoading] = useState(false);
+  const [lastPayload, setLastPayload] = useState(null);
+  const streamedCharsRef = useRef(0);
+  const [, forceMetricsTick] = useState(0);
+
+  function addEvent(label, detail = '') {
+    setEvents((current) => [
+      { id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, label, detail, time: nowStamp() },
+      ...current,
+    ].slice(0, 14));
+  }
+
+  function refreshAuth() {
+    const next = inferAuthState();
+    setAuthState(next);
+    return next;
+  }
+
+  async function loadToolCatalog() {
+    setToolsLoading(true);
+    addEvent('Catalog lookup', 'Checking for generated MCP OpenAPI spec');
+
+    for (const candidate of OPENAPI_CANDIDATE_URLS) {
+      try {
+        const response = await fetch(candidate, { cache: 'no-store' });
+        if (!response.ok) {
+          continue;
+        }
+        const spec = await response.json();
+        const tools = extractToolsFromOpenApi(spec);
+        if (tools.length) {
+          setToolCatalog(tools);
+          setToolSource(candidate);
+          addEvent('Catalog loaded', `Loaded ${tools.length} operations from ${candidate}`);
+          setToolsLoading(false);
+          return;
+        }
+      } catch (error) {
+        addEvent('Catalog error', error.message);
+      }
+    }
+
+    setToolCatalog(sampleTools());
+    setToolSource('Embedded sample catalog');
+    addEvent('Catalog fallback', 'Using embedded sample tool catalog');
+    setToolsLoading(false);
+  }
+
+  useEffect(() => {
+    refreshAuth();
+    loadToolCatalog();
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      forceMetricsTick((x) => x + 1);
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const text = prompt.trim();
+    if (!text || isStreaming) {
+      return;
+    }
+
+    setPrompt('');
+    setMessages((current) => [...current, makeMessage('user', text)]);
+    setLastPayload({ prompt: text });
+    addEvent('Request queued', 'Sending prompt to /api/chat');
+
+    setTransportStatus('streaming');
+    setIsStreaming(true);
+
+    let assistantId = null;
+    let assistantText = '';
 
     try {
-        const res = await fetch(API_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt: text })
-        });
+      const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: text }),
+      });
 
-        if (res.status === 401 || res.status === 403) {
-            appendLog('ERROR: SESSION_EXPIRED', 'text-red-500');
-            checkAuth();
-            return;
+      if (response.status === 401 || response.status === 403) {
+        setMessages((current) => [...current, makeMessage('error', 'SESSION_EXPIRED')]);
+        setAuthState('unauthorized');
+        addEvent('Auth required', `HTTP ${response.status}`);
+        setTransportStatus('unauthorized');
+        return;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        setMessages((current) => [...current, makeMessage('error', errorText || `HTTP ${response.status}`)]);
+        addEvent('Request failed', `HTTP ${response.status}`);
+        setTransportStatus('disconnected');
+        return;
+      }
+
+      setAuthState('connected');
+      addEvent('Request accepted', response.body ? 'Streaming response available' : 'JSON response fallback');
+
+      assistantId = `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      setMessages((current) => [
+        ...current,
+        { id: assistantId, role: 'assistant', text: '', timestamp: nowStamp() },
+      ]);
+
+      if (!response.body || !response.body.getReader) {
+        const data = await response.json();
+        const fallbackText = data.response || JSON.stringify(data);
+        assistantText = fallbackText;
+        streamedCharsRef.current += fallbackText.length;
+        setLastPayload(data);
+        setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: fallbackText } : msg)));
+        addEvent('JSON response', `Received ${fallbackText.length} characters`);
+        setTransportStatus('connected');
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
         }
 
-        if (!res.ok) {
-            const errText = await res.text();
-            appendLog(`ERROR: ${errText}`, 'text-red-500');
-            return;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const packet = normalizeStreamLine(line);
+          if (!packet) {
+            continue;
+          }
+
+          if (packet.error) {
+            setMessages((current) => [...current, makeMessage('error', String(packet.error))]);
+            addEvent('Stream error', String(packet.error));
+            continue;
+          }
+
+          if (packet.type === 'delta' && typeof packet.delta === 'string') {
+            assistantText += packet.delta;
+            streamedCharsRef.current += packet.delta.length;
+            setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: assistantText } : msg)));
+            continue;
+          }
+
+          if (packet.type === 'done') {
+            setLastPayload(packet);
+            addEvent('Stream done', 'Received completion marker');
+          }
         }
+      }
 
-        if (!res.body || !res.body.getReader) {
-            const data = await res.json();
-            appendLog(data.response || JSON.stringify(data), 'text-white');
-            return;
+      if (buffer.trim()) {
+        const packet = normalizeStreamLine(buffer);
+        if (packet && packet.type === 'delta' && typeof packet.delta === 'string') {
+          assistantText += packet.delta;
+          streamedCharsRef.current += packet.delta.length;
+          setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: assistantText } : msg)));
         }
+      }
 
-        const responseDiv = appendLog('', 'text-white');
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let responseText = '';
-
-        const processLine = (line) => {
-            const trimmed = line.trim();
-            if (!trimmed) return;
-            try {
-                const obj = JSON.parse(trimmed);
-                if (obj.type === 'delta' && obj.delta !== undefined) {
-                    responseText += obj.delta;
-                    responseDiv.innerText = responseText;
-                    return;
-                }
-                if (obj.error) {
-                    appendLog(`ERROR: ${obj.error}`, 'text-red-500');
-                    return;
-                }
-            } catch (err) {
-                responseText += line;
-                responseDiv.innerText = responseText;
-            }
-        };
-
-        while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split('\n');
-            buffer = lines.pop();
-            lines.forEach(processLine);
-        }
-
-        if (buffer.trim()) {
-            processLine(buffer);
-        }
-
-    } catch (err) {
-        appendLog(`SYSTEM FAILURE: ${err.message}`, 'text-red-500');
+      addEvent('Stream complete', `Received ${assistantText.length} characters`);
+      setTransportStatus('connected');
+    } catch (error) {
+      setMessages((current) => [...current, makeMessage('error', error.message)]);
+      addEvent('Transport error', error.message);
+      setTransportStatus('disconnected');
+    } finally {
+      setIsStreaming(false);
+      setTransportStatus((current) => (current === 'streaming' ? 'connected' : current));
+      refreshAuth();
     }
+  }
+
+  const statusState = isStreaming ? 'streaming' : transportStatus === 'idle' ? authState : transportStatus;
+  const statusLabel = isStreaming
+    ? 'STREAMING'
+    : statusState === 'connected'
+      ? 'CONNECTED'
+      : statusState === 'unauthorized'
+        ? 'AUTH REQUIRED'
+        : statusState === 'disconnected'
+          ? 'DISCONNECTED'
+          : 'READY';
+
+  const assistantMessages = messages.filter((msg) => msg.role === 'assistant').length;
+  const errors = messages.filter((msg) => msg.role === 'error').length;
+  const metrics = [
+    {
+      label: 'Session State',
+      value: authState === 'connected' ? 'Authorized' : 'Sign-In Needed',
+      detail: authState === 'connected' ? 'Cookie detected in browser context' : 'Use OIDC login to create session',
+      tone: authState === 'connected' ? 'success' : 'warning',
+    },
+    {
+      label: 'Assistant Responses',
+      value: String(assistantMessages),
+      detail: `${errors} error event(s)`,
+      tone: errors ? 'warning' : 'info',
+    },
+    {
+      label: 'Streamed Characters',
+      value: String(streamedCharsRef.current),
+      detail: isStreaming ? 'Active stream' : 'Accumulated this page session',
+      tone: isStreaming ? 'info' : 'neutral',
+    },
+    {
+      label: 'Tool Catalog Entries',
+      value: String(toolCatalog.length),
+      detail: toolSource,
+      tone: toolCatalog.length ? 'success' : 'neutral',
+    },
+  ];
+
+  function clearTranscript() {
+    setMessages([
+      makeMessage('system', 'Transcript cleared.'),
+      makeMessage('system', 'Compose a new dashboard interaction. Components remain reusable.'),
+    ]);
+    addEvent('Transcript cleared', 'Chat messages removed from local state');
+  }
+
+  function handleLogin() {
+    addEvent('Redirecting', 'Navigating to /auth/login');
+    window.location.href = AUTH_URL;
+  }
+
+  const toolbar = html`
+    <div className="flex flex-wrap items-center gap-2">
+      <${StatusBadge} state=${statusState} label=${statusLabel} />
+      <${ActionButton} label="Refresh Auth" onClick=${refreshAuth} />
+      <${ActionButton} label="Reload Tools" onClick=${loadToolCatalog} disabled=${toolsLoading} />
+      <${ActionButton} label="Clear" onClick=${clearTranscript} tone="danger" />
+    </div>
+  `;
+
+  const sidebar = html`
+    <${Panel} title="Component Library" subtitle="Reusable React + Tailwind building blocks for specialized agent dashboards.">
+      <div className="space-y-3">
+        <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-slate-200">
+          Version <span className="font-mono text-white">v${COMPONENT_LIBRARY_VERSION}</span>
+        </div>
+        <${LibraryList} />
+      </div>
+    </${Panel}>
+
+    <${Panel} title="Tool Catalog" subtitle="Auto-loads MCP OpenAPI output when available.">
+      <${ToolCatalog} tools=${toolCatalog} sourceLabel=${toolSource} loading=${toolsLoading} />
+    </${Panel}>
+
+    <${Panel} title="Activity" subtitle="Transport and UI events for debugging.">
+      <${Timeline} events=${events} />
+    </${Panel}>
+
+    <${Panel} title="Last Payload" subtitle="Preview the last request or protocol packet.">
+      <${JsonPreview} data=${lastPayload} emptyLabel="No requests sent yet." />
+    </${Panel}>
+  `;
+
+  return html`
+    <${AppShell}
+      title="AgentCore Operator Console"
+      subtitle="Static-hosted dashboard shell using reusable React/Tailwind components (no bundler required)."
+      status=${html``}
+      toolbar=${toolbar}
+      sidebar=${sidebar}
+    >
+      <${Panel}
+        title="Session Overview"
+        subtitle="Composable cards for auth, metrics, and runtime state."
+      >
+        <div className="space-y-4">
+          <${MetricGrid} items=${metrics} />
+          ${authState !== 'connected' ? html`<${AuthCard} onLogin=${handleLogin} />` : null}
+        </div>
+      </${Panel}>
+
+      <${Panel}
+        title="Conversation"
+        subtitle="Drop this transcript panel into any specialist dashboard."
+        className="min-h-[22rem]"
+        bodyClassName="space-y-4"
+      >
+        <div className="max-h-[26rem] overflow-auto pr-1">
+          <${Transcript} items=${messages} isStreaming=${isStreaming} />
+        </div>
+        <${PromptComposer}
+          value=${prompt}
+          onChange=${setPrompt}
+          onSubmit=${handleSubmit}
+          disabled=${isStreaming}
+          placeholder="Ask for research, analytics, or tool execution..."
+          submitLabel=${isStreaming ? 'Streaming...' : 'Send'}
+        />
+      </${Panel}>
+    </${AppShell}>
+  `;
 }
 
-function appendLog(text, className) {
-    const div = document.createElement('div');
-    div.className = className;
-    div.innerText = text;
-    document.getElementById('chat-window').appendChild(div);
-    document.getElementById('chat-window').scrollTop = document.getElementById('chat-window').scrollHeight;
-    return div;
-}
-
-// Init
-checkAuth();
+const root = createRoot(document.getElementById('app'));
+root.render(html`<${App} />`);

--- a/examples/5-integrated/frontend/components.js
+++ b/examples/5-integrated/frontend/components.js
@@ -1,0 +1,305 @@
+import React from 'https://esm.sh/react@18.3.1';
+import htm from 'https://esm.sh/htm@3.1.1';
+
+export const html = htm.bind(React.createElement);
+
+export const COMPONENT_LIBRARY_VERSION = '0.1.0';
+
+function cx(...parts) {
+  return parts.filter(Boolean).join(' ');
+}
+
+const STATUS_STYLES = {
+  connected: 'bg-emerald-500/15 text-emerald-200 ring-emerald-400/30',
+  unauthorized: 'bg-amber-500/15 text-amber-100 ring-amber-300/30',
+  disconnected: 'bg-rose-500/15 text-rose-100 ring-rose-300/30',
+  streaming: 'bg-sky-500/15 text-sky-100 ring-sky-300/30',
+  idle: 'bg-slate-500/15 text-slate-100 ring-slate-300/30',
+};
+
+const TONE_STYLES = {
+  neutral: 'from-slate-200/10 to-slate-200/0 text-slate-100',
+  success: 'from-emerald-300/15 to-emerald-200/0 text-emerald-100',
+  warning: 'from-amber-300/15 to-amber-200/0 text-amber-100',
+  danger: 'from-rose-300/15 to-rose-200/0 text-rose-100',
+  info: 'from-sky-300/15 to-sky-200/0 text-sky-100',
+};
+
+export function StatusBadge({ state = 'idle', label }) {
+  return html`
+    <span
+      className=${cx(
+        'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ring-1 backdrop-blur-sm',
+        STATUS_STYLES[state] || STATUS_STYLES.idle,
+      )}
+    >
+      <span className=${cx('h-1.5 w-1.5 rounded-full', state === 'streaming' ? 'animate-pulse bg-sky-300' : 'bg-current opacity-80')}></span>
+      ${label || state.toUpperCase()}
+    </span>
+  `;
+}
+
+export function Panel({ title, subtitle, actions = null, className = '', bodyClassName = '', children }) {
+  return html`
+    <section className=${cx('glass-panel rounded-2xl border border-white/10', className)}>
+      <header className="flex items-start justify-between gap-3 border-b border-white/5 px-4 py-3 sm:px-5">
+        <div>
+          <h2 className="text-sm font-semibold tracking-wide text-white">${title}</h2>
+          ${subtitle
+            ? html`<p className="mt-1 text-xs text-slate-300/80">${subtitle}</p>`
+            : null}
+        </div>
+        ${actions ? html`<div className="flex items-center gap-2">${actions}</div>` : null}
+      </header>
+      <div className=${cx('px-4 py-4 sm:px-5', bodyClassName)}>${children}</div>
+    </section>
+  `;
+}
+
+export function AppShell({ title, subtitle, status, toolbar = null, sidebar = null, children }) {
+  return html`
+    <div className="dashboard-shell min-h-screen text-slate-100">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-5 sm:px-6 lg:px-8">
+        <header className="glass-panel rounded-2xl border border-white/10 px-4 py-4 sm:px-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-sky-200/70">AgentCore Dashboard Kit</p>
+              <h1 className="mt-1 text-xl font-semibold text-white sm:text-2xl">${title}</h1>
+              ${subtitle ? html`<p className="mt-1 text-sm text-slate-300/85">${subtitle}</p>` : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              ${status}
+              ${toolbar}
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,1fr)]">
+          <div className="flex min-h-0 flex-col gap-5">${children}</div>
+          <aside className="flex min-h-0 flex-col gap-5">${sidebar}</aside>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function ActionButton({ label, onClick, disabled = false, tone = 'neutral' }) {
+  const toneClass = {
+    neutral: 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10',
+    primary: 'border-sky-300/25 bg-sky-300/10 text-sky-100 hover:bg-sky-300/20',
+    danger: 'border-rose-300/25 bg-rose-300/10 text-rose-100 hover:bg-rose-300/20',
+  }[tone] || 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10';
+
+  return html`
+    <button
+      type="button"
+      className=${cx(
+        'rounded-lg border px-3 py-1.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
+        toneClass,
+      )}
+      onClick=${onClick}
+      disabled=${disabled}
+    >
+      ${label}
+    </button>
+  `;
+}
+
+export function MetricGrid({ items = [] }) {
+  return html`
+    <div className="grid gap-3 sm:grid-cols-2">${items.map((item) => html`<${MetricCard} ...${item} />`)}</div>
+  `;
+}
+
+export function MetricCard({ label, value, detail, tone = 'neutral' }) {
+  return html`
+    <div className=${cx('rounded-xl border border-white/10 bg-gradient-to-b p-3', TONE_STYLES[tone] || TONE_STYLES.neutral)}>
+      <div className="text-xs uppercase tracking-wide text-slate-300/85">${label}</div>
+      <div className="mt-2 text-xl font-semibold tracking-tight">${value}</div>
+      ${detail ? html`<div className="mt-1 text-xs text-slate-300/80">${detail}</div>` : null}
+    </div>
+  `;
+}
+
+export function PromptComposer({ value, onChange, onSubmit, disabled = false, placeholder = 'Ask the agent...', submitLabel = 'Send' }) {
+  return html`
+    <form className="flex flex-col gap-3" onSubmit=${onSubmit}>
+      <label className="sr-only" htmlFor="prompt">Prompt</label>
+      <textarea
+        id="prompt"
+        rows="3"
+        className="w-full resize-y rounded-xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 outline-none ring-0 placeholder:text-slate-400/70 focus:border-sky-300/40"
+        placeholder=${placeholder}
+        value=${value}
+        onInput=${(event) => onChange(event.target.value)}
+        disabled=${disabled}
+      />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-slate-300/70">Supports JSON streaming (`application/x-ndjson`) and JSON fallback responses.</p>
+        <button
+          type="submit"
+          disabled=${disabled || !value.trim()}
+          className="rounded-xl border border-sky-300/30 bg-sky-300/10 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-300/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          ${submitLabel}
+        </button>
+      </div>
+    </form>
+  `;
+}
+
+export function AuthCard({ onLogin, message = 'Authentication required to start the session.', loginLabel = 'Sign in via OIDC' }) {
+  return html`
+    <div className="rounded-xl border border-amber-300/20 bg-amber-300/5 p-4 text-sm text-amber-100">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="font-semibold">Session Gate</div>
+          <p className="mt-1 text-xs text-amber-100/80">${message}</p>
+        </div>
+        <button
+          type="button"
+          onClick=${onLogin}
+          className="rounded-xl border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-amber-100 transition hover:bg-amber-300/20"
+        >
+          ${loginLabel}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+export function Transcript({ items = [], isStreaming = false }) {
+  if (!items.length) {
+    return html`<${EmptyState} title="No transcript yet" description="Send a prompt to populate the conversation transcript." />`;
+  }
+
+  return html`
+    <div className="space-y-3">
+      ${items.map(
+        (item) => html`<${TranscriptLine} key=${item.id} item=${item} />`,
+      )}
+      ${isStreaming
+        ? html`<div className="inline-flex items-center gap-2 rounded-lg border border-sky-300/20 bg-sky-300/5 px-3 py-2 text-xs text-sky-100">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-sky-300"></span>
+            Streaming response...
+          </div>`
+        : null}
+    </div>
+  `;
+}
+
+export function TranscriptLine({ item }) {
+  const roleTone = {
+    system: 'border-slate-300/10 bg-slate-300/5 text-slate-200',
+    user: 'border-sky-300/20 bg-sky-300/10 text-sky-100',
+    assistant: 'border-emerald-300/20 bg-emerald-300/10 text-emerald-100',
+    error: 'border-rose-300/20 bg-rose-300/10 text-rose-100',
+  }[item.role] || 'border-white/10 bg-white/5 text-slate-100';
+
+  return html`
+    <article className=${cx('rounded-xl border p-3', roleTone)}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] opacity-80">${item.role}</span>
+        ${item.timestamp ? html`<span className="text-[11px] opacity-70">${item.timestamp}</span>` : null}
+      </div>
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5">${item.text || ''}</pre>
+    </article>
+  `;
+}
+
+export function Timeline({ events = [] }) {
+  if (!events.length) {
+    return html`<${EmptyState} title="No activity" description="Runtime and transport events will appear here." compact=${true} />`;
+  }
+
+  return html`
+    <ol className="space-y-2">
+      ${events.map(
+        (event) => html`
+          <li key=${event.id} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="font-medium text-white">${event.label}</span>
+              <span className="text-slate-300/70">${event.time}</span>
+            </div>
+            ${event.detail ? html`<p className="mt-1 text-xs text-slate-300/80">${event.detail}</p>` : null}
+          </li>
+        `,
+      )}
+    </ol>
+  `;
+}
+
+export function ToolCatalog({ tools = [], sourceLabel = 'Example schema', loading = false }) {
+  if (loading) {
+    return html`<p className="text-xs text-slate-300/80">Loading tool metadata...</p>`;
+  }
+
+  return html`
+    <div className="space-y-3">
+      <p className="text-xs text-slate-300/75">Source: ${sourceLabel}</p>
+      ${tools.length
+        ? html`
+            <ul className="space-y-2">
+              ${tools.map(
+                (tool) => html`
+                  <li key=${tool.id} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium text-white">${tool.name}</p>
+                        <p className="mt-1 text-xs text-slate-300/80">${tool.description || 'No description'}</p>
+                      </div>
+                      ${tool.method
+                        ? html`<span className="rounded-md border border-sky-300/20 bg-sky-300/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-100">${tool.method}</span>`
+                        : null}
+                    </div>
+                  </li>
+                `,
+              )}
+            </ul>
+          `
+        : html`<${EmptyState} title="No tools discovered" description="Add an OpenAPI spec to populate specialized tool panels." compact=${true} />`}
+    </div>
+  `;
+}
+
+export function JsonPreview({ data, emptyLabel = 'No payload yet' }) {
+  return html`
+    <div className="rounded-xl border border-white/10 bg-slate-950/70">
+      <div className="border-b border-white/5 px-3 py-2 text-xs uppercase tracking-wide text-slate-300/75">Payload Preview</div>
+      <pre className="max-h-64 overflow-auto p-3 text-xs leading-5 text-slate-100"><code>${data ? JSON.stringify(data, null, 2) : emptyLabel}</code></pre>
+    </div>
+  `;
+}
+
+export function EmptyState({ title, description, compact = false }) {
+  return html`
+    <div className=${cx('rounded-xl border border-dashed border-white/15 bg-white/5 text-center text-slate-300/80', compact ? 'p-3' : 'p-5')}>
+      <p className="text-sm font-medium text-slate-100">${title}</p>
+      <p className="mt-1 text-xs">${description}</p>
+    </div>
+  `;
+}
+
+export function LibraryList() {
+  const components = [
+    'AppShell',
+    'Panel',
+    'StatusBadge',
+    'ActionButton',
+    'MetricGrid / MetricCard',
+    'PromptComposer',
+    'AuthCard',
+    'Transcript / TranscriptLine',
+    'Timeline',
+    'ToolCatalog',
+    'JsonPreview',
+  ];
+
+  return html`
+    <ul className="grid gap-2 text-xs sm:grid-cols-2">
+      ${components.map(
+        (name) => html`<li key=${name} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-slate-100">${name}</li>`,
+      )}
+    </ul>
+  `;
+}

--- a/examples/5-integrated/frontend/index.html
+++ b/examples/5-integrated/frontend/index.html
@@ -3,51 +3,36 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AgentCore // Terminal</title>
+    <title>AgentCore // Dashboard Kit</title>
+    <script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Sora', 'system-ui', 'sans-serif'],
+                        mono: ['IBM Plex Mono', 'monospace']
+                    },
+                    boxShadow: {
+                        panel: '0 18px 60px rgba(2, 6, 23, 0.35)'
+                    }
+                }
+            }
+        };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Sora:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="style.css" rel="stylesheet">
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap');
-        body { font-family: 'Fira Code', monospace; }
-    </style>
 </head>
-<body class="bg-black text-green-500 h-screen w-screen overflow-hidden flex flex-col p-4 crt">
-
-    <!-- Header -->
-    <header class="flex justify-between border-b border-green-800 pb-2 mb-4">
-        <div>
-            <h1 class="text-xl font-bold">AGENT_CORE v2.0</h1>
-            <p class="text-xs text-green-700">SECURE CONNECTION ESTABLISHED</p>
+<body class="dashboard-shell font-sans antialiased">
+    <div id="app"></div>
+    <noscript>
+        <div style="padding: 1rem; color: #fff; background: #0f172a; font-family: sans-serif;">
+            This frontend requires JavaScript to render the React component library.
         </div>
-        <div id="status" class="text-right">
-            <span class="text-red-500 blink">DISCONNECTED</span>
-        </div>
-    </header>
-
-    <!-- Chat Output -->
-    <main id="chat-window" class="flex-grow overflow-y-auto mb-4 space-y-2 p-2 scrollbar-hide">
-        <div class="text-green-800">System initialization...</div>
-        <div class="text-green-800">Loading neural interfaces...</div>
-        <div class="text-green-500">Welcome, Operator. Authentication required.</div>
-    </main>
-
-    <!-- Input Area -->
-    <footer class="border-t border-green-800 pt-2">
-        <div id="auth-panel" class="hidden">
-            <button onclick="login()" class="border border-green-500 px-4 py-2 hover:bg-green-900 transition w-full text-left">
-                > INITIATE_OAUTH_SEQUENCE()
-            </button>
-        </div>
-
-        <form id="chat-form" class="hidden flex gap-2" onsubmit="sendMessage(event)">
-            <span class="pt-2">></span>
-            <input type="text" id="prompt"
-                class="bg-black border-none outline-none flex-grow text-green-400 focus:ring-0"
-                placeholder="Enter command..." autocomplete="off">
-            <button type="submit" class="text-xs border border-green-800 px-2 hover:bg-green-900">EXEC</button>
-        </form>
-    </footer>
-
-    <script src="app.js"></script>
+    </noscript>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/examples/5-integrated/frontend/style.css
+++ b/examples/5-integrated/frontend/style.css
@@ -1,30 +1,95 @@
-.crt::before {
-    content: " ";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.25) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.06), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.06));
-    z-index: 2;
-    background-size: 100% 2px, 3px 100%;
+:root {
+    color-scheme: dark;
+    --bg-1: #020617;
+    --bg-2: #111827;
+    --bg-3: #1e293b;
+    --glow-a: rgba(56, 189, 248, 0.14);
+    --glow-b: rgba(16, 185, 129, 0.12);
+    --glow-c: rgba(244, 114, 182, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+    min-height: 100%;
+}
+
+body {
+    margin: 0;
+    background:
+        radial-gradient(circle at 12% 14%, var(--glow-a), transparent 42%),
+        radial-gradient(circle at 88% 12%, var(--glow-b), transparent 46%),
+        radial-gradient(circle at 50% 100%, var(--glow-c), transparent 45%),
+        linear-gradient(160deg, var(--bg-1), var(--bg-2) 55%, var(--bg-3));
+    background-attachment: fixed;
+}
+
+.dashboard-shell {
+    position: relative;
+}
+
+.dashboard-shell::before {
+    content: "";
+    position: fixed;
+    inset: 0;
     pointer-events: none;
+    opacity: 0.35;
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 28px 28px;
+    mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
 }
 
-.blink {
-    animation: blinker 1s linear infinite;
+.glass-panel {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.68));
+    backdrop-filter: blur(14px);
+    box-shadow: 0 18px 60px rgba(2, 6, 23, 0.35);
 }
 
-@keyframes blinker {
-    50% { opacity: 0; }
+pre,
+code,
+textarea {
+    font-family: "IBM Plex Mono", monospace;
 }
 
-/* Custom Scrollbar */
-.scrollbar-hide::-webkit-scrollbar {
-    display: none;
+pre {
+    margin: 0;
 }
-.scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+
+/* Scrollbars */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.35) rgba(15, 23, 42, 0.25);
+}
+
+*::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+*::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    background-color: rgba(148, 163, 184, 0.35);
+}
+
+*::-webkit-scrollbar-track {
+    background: rgba(15, 23, 42, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }

--- a/templates/agent-project/frontend/app.js
+++ b/templates/agent-project/frontend/app.js
@@ -1,109 +1,436 @@
+import React, { useEffect, useRef, useState } from 'https://esm.sh/react@18.3.1';
+import { createRoot } from 'https://esm.sh/react-dom@18.3.1/client';
+import htm from 'https://esm.sh/htm@3.1.1';
+import {
+  ActionButton,
+  AppShell,
+  AuthCard,
+  COMPONENT_LIBRARY_VERSION,
+  JsonPreview,
+  LibraryList,
+  MetricGrid,
+  Panel,
+  PromptComposer,
+  StatusBadge,
+  Timeline,
+  ToolCatalog,
+  Transcript,
+} from './components.js';
+
+const html = htm.bind(React.createElement);
+
 const API_URL = '/api/chat';
 const AUTH_URL = '/auth/login';
+const OPENAPI_CANDIDATE_URLS = ['/docs/api/mcp-tools-v1.openapi.json', '/mcp-tools-v1.openapi.json'];
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'options', 'head']);
 
-// Check for session cookie (simple check)
-function checkAuth() {
-    if (document.cookie.includes('session_id')) {
-        document.getElementById('status').innerHTML = '<span class="text-green-500">CONNECTED</span>';
-        document.getElementById('chat-form').classList.remove('hidden');
-        document.getElementById('auth-panel').classList.add('hidden');
-    } else {
-        document.getElementById('status').innerHTML = '<span class="text-red-500 blink">UNAUTHORIZED</span>';
-        document.getElementById('chat-form').classList.add('hidden');
-        document.getElementById('auth-panel').classList.remove('hidden');
+function nowStamp() {
+  return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function makeMessage(role, text) {
+  return {
+    id: `${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    role,
+    text,
+    timestamp: nowStamp(),
+  };
+}
+
+function normalizeStreamLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return { type: 'delta', delta: line };
+  }
+}
+
+function extractToolsFromOpenApi(spec) {
+  if (!spec || !spec.paths || typeof spec.paths !== 'object') {
+    return [];
+  }
+
+  const tools = [];
+  for (const [path, methods] of Object.entries(spec.paths)) {
+    if (!methods || typeof methods !== 'object') {
+      continue;
     }
+
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!HTTP_METHODS.has(method)) {
+        continue;
+      }
+
+      if (!operation || typeof operation !== 'object') {
+        continue;
+      }
+
+      tools.push({
+        id: `${method}:${path}`,
+        method: method.toUpperCase(),
+        name: operation.operationId || path,
+        description: operation.summary || operation.description || '',
+      });
+    }
+  }
+
+  return tools.slice(0, 12);
 }
 
-function login() {
-    window.location.href = AUTH_URL;
+function sampleTools() {
+  return [
+    {
+      id: 'tool:s3.list_objects',
+      method: 'MCP',
+      name: 's3.list_objects',
+      description: 'List objects in a tenant-scoped S3 prefix for dashboard exploration.',
+    },
+    {
+      id: 'tool:analytics.run_query',
+      method: 'MCP',
+      name: 'analytics.run_query',
+      description: 'Execute a scoped analytics query and stream results back to the panel.',
+    },
+    {
+      id: 'tool:research.fetch_sources',
+      method: 'MCP',
+      name: 'research.fetch_sources',
+      description: 'Resolve and summarize source documents for deep-research workflows.',
+    },
+  ];
 }
 
-async function sendMessage(e) {
-    e.preventDefault();
-    const input = document.getElementById('prompt');
-    const text = input.value;
-    if (!text) return;
+function inferAuthState() {
+  return document.cookie.includes('session_id') ? 'connected' : 'unauthorized';
+}
 
-    appendLog(`> ${text}`, 'text-green-300');
-    input.value = '';
+function App() {
+  const [authState, setAuthState] = useState(inferAuthState());
+  const [prompt, setPrompt] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [transportStatus, setTransportStatus] = useState('idle');
+  const [messages, setMessages] = useState(() => [
+    makeMessage('system', 'AgentCore frontend component library loaded.'),
+    makeMessage('system', 'Use these React/Tailwind panels to compose specialized dashboards.'),
+  ]);
+  const [events, setEvents] = useState(() => [
+    { id: 'boot', label: 'UI booted', detail: `Component library v${COMPONENT_LIBRARY_VERSION}`, time: nowStamp() },
+  ]);
+  const [toolCatalog, setToolCatalog] = useState(sampleTools());
+  const [toolSource, setToolSource] = useState('Embedded sample catalog');
+  const [toolsLoading, setToolsLoading] = useState(false);
+  const [lastPayload, setLastPayload] = useState(null);
+  const streamedCharsRef = useRef(0);
+  const [, forceMetricsTick] = useState(0);
+
+  function addEvent(label, detail = '') {
+    setEvents((current) => [
+      { id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, label, detail, time: nowStamp() },
+      ...current,
+    ].slice(0, 14));
+  }
+
+  function refreshAuth() {
+    const next = inferAuthState();
+    setAuthState(next);
+    return next;
+  }
+
+  async function loadToolCatalog() {
+    setToolsLoading(true);
+    addEvent('Catalog lookup', 'Checking for generated MCP OpenAPI spec');
+
+    for (const candidate of OPENAPI_CANDIDATE_URLS) {
+      try {
+        const response = await fetch(candidate, { cache: 'no-store' });
+        if (!response.ok) {
+          continue;
+        }
+        const spec = await response.json();
+        const tools = extractToolsFromOpenApi(spec);
+        if (tools.length) {
+          setToolCatalog(tools);
+          setToolSource(candidate);
+          addEvent('Catalog loaded', `Loaded ${tools.length} operations from ${candidate}`);
+          setToolsLoading(false);
+          return;
+        }
+      } catch (error) {
+        addEvent('Catalog error', error.message);
+      }
+    }
+
+    setToolCatalog(sampleTools());
+    setToolSource('Embedded sample catalog');
+    addEvent('Catalog fallback', 'Using embedded sample tool catalog');
+    setToolsLoading(false);
+  }
+
+  useEffect(() => {
+    refreshAuth();
+    loadToolCatalog();
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      forceMetricsTick((x) => x + 1);
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    const text = prompt.trim();
+    if (!text || isStreaming) {
+      return;
+    }
+
+    setPrompt('');
+    setMessages((current) => [...current, makeMessage('user', text)]);
+    setLastPayload({ prompt: text });
+    addEvent('Request queued', 'Sending prompt to /api/chat');
+
+    setTransportStatus('streaming');
+    setIsStreaming(true);
+
+    let assistantId = null;
+    let assistantText = '';
 
     try {
-        const res = await fetch(API_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt: text })
-        });
+      const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: text }),
+      });
 
-        if (res.status === 401 || res.status === 403) {
-            appendLog('ERROR: SESSION_EXPIRED', 'text-red-500');
-            checkAuth();
-            return;
+      if (response.status === 401 || response.status === 403) {
+        setMessages((current) => [...current, makeMessage('error', 'SESSION_EXPIRED')]);
+        setAuthState('unauthorized');
+        addEvent('Auth required', `HTTP ${response.status}`);
+        setTransportStatus('unauthorized');
+        return;
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        setMessages((current) => [...current, makeMessage('error', errorText || `HTTP ${response.status}`)]);
+        addEvent('Request failed', `HTTP ${response.status}`);
+        setTransportStatus('disconnected');
+        return;
+      }
+
+      setAuthState('connected');
+      addEvent('Request accepted', response.body ? 'Streaming response available' : 'JSON response fallback');
+
+      assistantId = `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      setMessages((current) => [
+        ...current,
+        { id: assistantId, role: 'assistant', text: '', timestamp: nowStamp() },
+      ]);
+
+      if (!response.body || !response.body.getReader) {
+        const data = await response.json();
+        const fallbackText = data.response || JSON.stringify(data);
+        assistantText = fallbackText;
+        streamedCharsRef.current += fallbackText.length;
+        setLastPayload(data);
+        setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: fallbackText } : msg)));
+        addEvent('JSON response', `Received ${fallbackText.length} characters`);
+        setTransportStatus('connected');
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
         }
 
-        if (!res.ok) {
-            const errText = await res.text();
-            appendLog(`ERROR: ${errText}`, 'text-red-500');
-            return;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const packet = normalizeStreamLine(line);
+          if (!packet) {
+            continue;
+          }
+
+          if (packet.error) {
+            setMessages((current) => [...current, makeMessage('error', String(packet.error))]);
+            addEvent('Stream error', String(packet.error));
+            continue;
+          }
+
+          if (packet.type === 'delta' && typeof packet.delta === 'string') {
+            assistantText += packet.delta;
+            streamedCharsRef.current += packet.delta.length;
+            setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: assistantText } : msg)));
+            continue;
+          }
+
+          if (packet.type === 'done') {
+            setLastPayload(packet);
+            addEvent('Stream done', 'Received completion marker');
+          }
         }
+      }
 
-        if (!res.body || !res.body.getReader) {
-            const data = await res.json();
-            appendLog(data.response || JSON.stringify(data), 'text-white');
-            return;
+      if (buffer.trim()) {
+        const packet = normalizeStreamLine(buffer);
+        if (packet && packet.type === 'delta' && typeof packet.delta === 'string') {
+          assistantText += packet.delta;
+          streamedCharsRef.current += packet.delta.length;
+          setMessages((current) => current.map((msg) => (msg.id === assistantId ? { ...msg, text: assistantText } : msg)));
         }
+      }
 
-        const responseDiv = appendLog('', 'text-white');
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let responseText = '';
-
-        const processLine = (line) => {
-            const trimmed = line.trim();
-            if (!trimmed) return;
-            try {
-                const obj = JSON.parse(trimmed);
-                if (obj.type === 'delta' && obj.delta !== undefined) {
-                    responseText += obj.delta;
-                    responseDiv.innerText = responseText;
-                    return;
-                }
-                if (obj.error) {
-                    appendLog(`ERROR: ${obj.error}`, 'text-red-500');
-                    return;
-                }
-            } catch (err) {
-                responseText += line;
-                responseDiv.innerText = responseText;
-            }
-        };
-
-        while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split('\n');
-            buffer = lines.pop();
-            lines.forEach(processLine);
-        }
-
-        if (buffer.trim()) {
-            processLine(buffer);
-        }
-
-    } catch (err) {
-        appendLog(`SYSTEM FAILURE: ${err.message}`, 'text-red-500');
+      addEvent('Stream complete', `Received ${assistantText.length} characters`);
+      setTransportStatus('connected');
+    } catch (error) {
+      setMessages((current) => [...current, makeMessage('error', error.message)]);
+      addEvent('Transport error', error.message);
+      setTransportStatus('disconnected');
+    } finally {
+      setIsStreaming(false);
+      setTransportStatus((current) => (current === 'streaming' ? 'connected' : current));
+      refreshAuth();
     }
+  }
+
+  const statusState = isStreaming ? 'streaming' : transportStatus === 'idle' ? authState : transportStatus;
+  const statusLabel = isStreaming
+    ? 'STREAMING'
+    : statusState === 'connected'
+      ? 'CONNECTED'
+      : statusState === 'unauthorized'
+        ? 'AUTH REQUIRED'
+        : statusState === 'disconnected'
+          ? 'DISCONNECTED'
+          : 'READY';
+
+  const assistantMessages = messages.filter((msg) => msg.role === 'assistant').length;
+  const errors = messages.filter((msg) => msg.role === 'error').length;
+  const metrics = [
+    {
+      label: 'Session State',
+      value: authState === 'connected' ? 'Authorized' : 'Sign-In Needed',
+      detail: authState === 'connected' ? 'Cookie detected in browser context' : 'Use OIDC login to create session',
+      tone: authState === 'connected' ? 'success' : 'warning',
+    },
+    {
+      label: 'Assistant Responses',
+      value: String(assistantMessages),
+      detail: `${errors} error event(s)`,
+      tone: errors ? 'warning' : 'info',
+    },
+    {
+      label: 'Streamed Characters',
+      value: String(streamedCharsRef.current),
+      detail: isStreaming ? 'Active stream' : 'Accumulated this page session',
+      tone: isStreaming ? 'info' : 'neutral',
+    },
+    {
+      label: 'Tool Catalog Entries',
+      value: String(toolCatalog.length),
+      detail: toolSource,
+      tone: toolCatalog.length ? 'success' : 'neutral',
+    },
+  ];
+
+  function clearTranscript() {
+    setMessages([
+      makeMessage('system', 'Transcript cleared.'),
+      makeMessage('system', 'Compose a new dashboard interaction. Components remain reusable.'),
+    ]);
+    addEvent('Transcript cleared', 'Chat messages removed from local state');
+  }
+
+  function handleLogin() {
+    addEvent('Redirecting', 'Navigating to /auth/login');
+    window.location.href = AUTH_URL;
+  }
+
+  const toolbar = html`
+    <div className="flex flex-wrap items-center gap-2">
+      <${StatusBadge} state=${statusState} label=${statusLabel} />
+      <${ActionButton} label="Refresh Auth" onClick=${refreshAuth} />
+      <${ActionButton} label="Reload Tools" onClick=${loadToolCatalog} disabled=${toolsLoading} />
+      <${ActionButton} label="Clear" onClick=${clearTranscript} tone="danger" />
+    </div>
+  `;
+
+  const sidebar = html`
+    <${Panel} title="Component Library" subtitle="Reusable React + Tailwind building blocks for specialized agent dashboards.">
+      <div className="space-y-3">
+        <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-slate-200">
+          Version <span className="font-mono text-white">v${COMPONENT_LIBRARY_VERSION}</span>
+        </div>
+        <${LibraryList} />
+      </div>
+    </${Panel}>
+
+    <${Panel} title="Tool Catalog" subtitle="Auto-loads MCP OpenAPI output when available.">
+      <${ToolCatalog} tools=${toolCatalog} sourceLabel=${toolSource} loading=${toolsLoading} />
+    </${Panel}>
+
+    <${Panel} title="Activity" subtitle="Transport and UI events for debugging.">
+      <${Timeline} events=${events} />
+    </${Panel}>
+
+    <${Panel} title="Last Payload" subtitle="Preview the last request or protocol packet.">
+      <${JsonPreview} data=${lastPayload} emptyLabel="No requests sent yet." />
+    </${Panel}>
+  `;
+
+  return html`
+    <${AppShell}
+      title="AgentCore Operator Console"
+      subtitle="Static-hosted dashboard shell using reusable React/Tailwind components (no bundler required)."
+      status=${html``}
+      toolbar=${toolbar}
+      sidebar=${sidebar}
+    >
+      <${Panel}
+        title="Session Overview"
+        subtitle="Composable cards for auth, metrics, and runtime state."
+      >
+        <div className="space-y-4">
+          <${MetricGrid} items=${metrics} />
+          ${authState !== 'connected' ? html`<${AuthCard} onLogin=${handleLogin} />` : null}
+        </div>
+      </${Panel}>
+
+      <${Panel}
+        title="Conversation"
+        subtitle="Drop this transcript panel into any specialist dashboard."
+        className="min-h-[22rem]"
+        bodyClassName="space-y-4"
+      >
+        <div className="max-h-[26rem] overflow-auto pr-1">
+          <${Transcript} items=${messages} isStreaming=${isStreaming} />
+        </div>
+        <${PromptComposer}
+          value=${prompt}
+          onChange=${setPrompt}
+          onSubmit=${handleSubmit}
+          disabled=${isStreaming}
+          placeholder="Ask for research, analytics, or tool execution..."
+          submitLabel=${isStreaming ? 'Streaming...' : 'Send'}
+        />
+      </${Panel}>
+    </${AppShell}>
+  `;
 }
 
-function appendLog(text, className) {
-    const div = document.createElement('div');
-    div.className = className;
-    div.innerText = text;
-    document.getElementById('chat-window').appendChild(div);
-    document.getElementById('chat-window').scrollTop = document.getElementById('chat-window').scrollHeight;
-    return div;
-}
-
-// Init
-checkAuth();
+const root = createRoot(document.getElementById('app'));
+root.render(html`<${App} />`);

--- a/templates/agent-project/frontend/components.js
+++ b/templates/agent-project/frontend/components.js
@@ -1,0 +1,305 @@
+import React from 'https://esm.sh/react@18.3.1';
+import htm from 'https://esm.sh/htm@3.1.1';
+
+export const html = htm.bind(React.createElement);
+
+export const COMPONENT_LIBRARY_VERSION = '0.1.0';
+
+function cx(...parts) {
+  return parts.filter(Boolean).join(' ');
+}
+
+const STATUS_STYLES = {
+  connected: 'bg-emerald-500/15 text-emerald-200 ring-emerald-400/30',
+  unauthorized: 'bg-amber-500/15 text-amber-100 ring-amber-300/30',
+  disconnected: 'bg-rose-500/15 text-rose-100 ring-rose-300/30',
+  streaming: 'bg-sky-500/15 text-sky-100 ring-sky-300/30',
+  idle: 'bg-slate-500/15 text-slate-100 ring-slate-300/30',
+};
+
+const TONE_STYLES = {
+  neutral: 'from-slate-200/10 to-slate-200/0 text-slate-100',
+  success: 'from-emerald-300/15 to-emerald-200/0 text-emerald-100',
+  warning: 'from-amber-300/15 to-amber-200/0 text-amber-100',
+  danger: 'from-rose-300/15 to-rose-200/0 text-rose-100',
+  info: 'from-sky-300/15 to-sky-200/0 text-sky-100',
+};
+
+export function StatusBadge({ state = 'idle', label }) {
+  return html`
+    <span
+      className=${cx(
+        'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ring-1 backdrop-blur-sm',
+        STATUS_STYLES[state] || STATUS_STYLES.idle,
+      )}
+    >
+      <span className=${cx('h-1.5 w-1.5 rounded-full', state === 'streaming' ? 'animate-pulse bg-sky-300' : 'bg-current opacity-80')}></span>
+      ${label || state.toUpperCase()}
+    </span>
+  `;
+}
+
+export function Panel({ title, subtitle, actions = null, className = '', bodyClassName = '', children }) {
+  return html`
+    <section className=${cx('glass-panel rounded-2xl border border-white/10', className)}>
+      <header className="flex items-start justify-between gap-3 border-b border-white/5 px-4 py-3 sm:px-5">
+        <div>
+          <h2 className="text-sm font-semibold tracking-wide text-white">${title}</h2>
+          ${subtitle
+            ? html`<p className="mt-1 text-xs text-slate-300/80">${subtitle}</p>`
+            : null}
+        </div>
+        ${actions ? html`<div className="flex items-center gap-2">${actions}</div>` : null}
+      </header>
+      <div className=${cx('px-4 py-4 sm:px-5', bodyClassName)}>${children}</div>
+    </section>
+  `;
+}
+
+export function AppShell({ title, subtitle, status, toolbar = null, sidebar = null, children }) {
+  return html`
+    <div className="dashboard-shell min-h-screen text-slate-100">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-5 sm:px-6 lg:px-8">
+        <header className="glass-panel rounded-2xl border border-white/10 px-4 py-4 sm:px-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-sky-200/70">AgentCore Dashboard Kit</p>
+              <h1 className="mt-1 text-xl font-semibold text-white sm:text-2xl">${title}</h1>
+              ${subtitle ? html`<p className="mt-1 text-sm text-slate-300/85">${subtitle}</p>` : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              ${status}
+              ${toolbar}
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,1fr)]">
+          <div className="flex min-h-0 flex-col gap-5">${children}</div>
+          <aside className="flex min-h-0 flex-col gap-5">${sidebar}</aside>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function ActionButton({ label, onClick, disabled = false, tone = 'neutral' }) {
+  const toneClass = {
+    neutral: 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10',
+    primary: 'border-sky-300/25 bg-sky-300/10 text-sky-100 hover:bg-sky-300/20',
+    danger: 'border-rose-300/25 bg-rose-300/10 text-rose-100 hover:bg-rose-300/20',
+  }[tone] || 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10';
+
+  return html`
+    <button
+      type="button"
+      className=${cx(
+        'rounded-lg border px-3 py-1.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-50',
+        toneClass,
+      )}
+      onClick=${onClick}
+      disabled=${disabled}
+    >
+      ${label}
+    </button>
+  `;
+}
+
+export function MetricGrid({ items = [] }) {
+  return html`
+    <div className="grid gap-3 sm:grid-cols-2">${items.map((item) => html`<${MetricCard} ...${item} />`)}</div>
+  `;
+}
+
+export function MetricCard({ label, value, detail, tone = 'neutral' }) {
+  return html`
+    <div className=${cx('rounded-xl border border-white/10 bg-gradient-to-b p-3', TONE_STYLES[tone] || TONE_STYLES.neutral)}>
+      <div className="text-xs uppercase tracking-wide text-slate-300/85">${label}</div>
+      <div className="mt-2 text-xl font-semibold tracking-tight">${value}</div>
+      ${detail ? html`<div className="mt-1 text-xs text-slate-300/80">${detail}</div>` : null}
+    </div>
+  `;
+}
+
+export function PromptComposer({ value, onChange, onSubmit, disabled = false, placeholder = 'Ask the agent...', submitLabel = 'Send' }) {
+  return html`
+    <form className="flex flex-col gap-3" onSubmit=${onSubmit}>
+      <label className="sr-only" htmlFor="prompt">Prompt</label>
+      <textarea
+        id="prompt"
+        rows="3"
+        className="w-full resize-y rounded-xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 outline-none ring-0 placeholder:text-slate-400/70 focus:border-sky-300/40"
+        placeholder=${placeholder}
+        value=${value}
+        onInput=${(event) => onChange(event.target.value)}
+        disabled=${disabled}
+      />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-slate-300/70">Supports JSON streaming (`application/x-ndjson`) and JSON fallback responses.</p>
+        <button
+          type="submit"
+          disabled=${disabled || !value.trim()}
+          className="rounded-xl border border-sky-300/30 bg-sky-300/10 px-4 py-2 text-sm font-semibold text-sky-100 transition hover:bg-sky-300/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          ${submitLabel}
+        </button>
+      </div>
+    </form>
+  `;
+}
+
+export function AuthCard({ onLogin, message = 'Authentication required to start the session.', loginLabel = 'Sign in via OIDC' }) {
+  return html`
+    <div className="rounded-xl border border-amber-300/20 bg-amber-300/5 p-4 text-sm text-amber-100">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="font-semibold">Session Gate</div>
+          <p className="mt-1 text-xs text-amber-100/80">${message}</p>
+        </div>
+        <button
+          type="button"
+          onClick=${onLogin}
+          className="rounded-xl border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-amber-100 transition hover:bg-amber-300/20"
+        >
+          ${loginLabel}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+export function Transcript({ items = [], isStreaming = false }) {
+  if (!items.length) {
+    return html`<${EmptyState} title="No transcript yet" description="Send a prompt to populate the conversation transcript." />`;
+  }
+
+  return html`
+    <div className="space-y-3">
+      ${items.map(
+        (item) => html`<${TranscriptLine} key=${item.id} item=${item} />`,
+      )}
+      ${isStreaming
+        ? html`<div className="inline-flex items-center gap-2 rounded-lg border border-sky-300/20 bg-sky-300/5 px-3 py-2 text-xs text-sky-100">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-sky-300"></span>
+            Streaming response...
+          </div>`
+        : null}
+    </div>
+  `;
+}
+
+export function TranscriptLine({ item }) {
+  const roleTone = {
+    system: 'border-slate-300/10 bg-slate-300/5 text-slate-200',
+    user: 'border-sky-300/20 bg-sky-300/10 text-sky-100',
+    assistant: 'border-emerald-300/20 bg-emerald-300/10 text-emerald-100',
+    error: 'border-rose-300/20 bg-rose-300/10 text-rose-100',
+  }[item.role] || 'border-white/10 bg-white/5 text-slate-100';
+
+  return html`
+    <article className=${cx('rounded-xl border p-3', roleTone)}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] opacity-80">${item.role}</span>
+        ${item.timestamp ? html`<span className="text-[11px] opacity-70">${item.timestamp}</span>` : null}
+      </div>
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5">${item.text || ''}</pre>
+    </article>
+  `;
+}
+
+export function Timeline({ events = [] }) {
+  if (!events.length) {
+    return html`<${EmptyState} title="No activity" description="Runtime and transport events will appear here." compact=${true} />`;
+  }
+
+  return html`
+    <ol className="space-y-2">
+      ${events.map(
+        (event) => html`
+          <li key=${event.id} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="font-medium text-white">${event.label}</span>
+              <span className="text-slate-300/70">${event.time}</span>
+            </div>
+            ${event.detail ? html`<p className="mt-1 text-xs text-slate-300/80">${event.detail}</p>` : null}
+          </li>
+        `,
+      )}
+    </ol>
+  `;
+}
+
+export function ToolCatalog({ tools = [], sourceLabel = 'Example schema', loading = false }) {
+  if (loading) {
+    return html`<p className="text-xs text-slate-300/80">Loading tool metadata...</p>`;
+  }
+
+  return html`
+    <div className="space-y-3">
+      <p className="text-xs text-slate-300/75">Source: ${sourceLabel}</p>
+      ${tools.length
+        ? html`
+            <ul className="space-y-2">
+              ${tools.map(
+                (tool) => html`
+                  <li key=${tool.id} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium text-white">${tool.name}</p>
+                        <p className="mt-1 text-xs text-slate-300/80">${tool.description || 'No description'}</p>
+                      </div>
+                      ${tool.method
+                        ? html`<span className="rounded-md border border-sky-300/20 bg-sky-300/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-100">${tool.method}</span>`
+                        : null}
+                    </div>
+                  </li>
+                `,
+              )}
+            </ul>
+          `
+        : html`<${EmptyState} title="No tools discovered" description="Add an OpenAPI spec to populate specialized tool panels." compact=${true} />`}
+    </div>
+  `;
+}
+
+export function JsonPreview({ data, emptyLabel = 'No payload yet' }) {
+  return html`
+    <div className="rounded-xl border border-white/10 bg-slate-950/70">
+      <div className="border-b border-white/5 px-3 py-2 text-xs uppercase tracking-wide text-slate-300/75">Payload Preview</div>
+      <pre className="max-h-64 overflow-auto p-3 text-xs leading-5 text-slate-100"><code>${data ? JSON.stringify(data, null, 2) : emptyLabel}</code></pre>
+    </div>
+  `;
+}
+
+export function EmptyState({ title, description, compact = false }) {
+  return html`
+    <div className=${cx('rounded-xl border border-dashed border-white/15 bg-white/5 text-center text-slate-300/80', compact ? 'p-3' : 'p-5')}>
+      <p className="text-sm font-medium text-slate-100">${title}</p>
+      <p className="mt-1 text-xs">${description}</p>
+    </div>
+  `;
+}
+
+export function LibraryList() {
+  const components = [
+    'AppShell',
+    'Panel',
+    'StatusBadge',
+    'ActionButton',
+    'MetricGrid / MetricCard',
+    'PromptComposer',
+    'AuthCard',
+    'Transcript / TranscriptLine',
+    'Timeline',
+    'ToolCatalog',
+    'JsonPreview',
+  ];
+
+  return html`
+    <ul className="grid gap-2 text-xs sm:grid-cols-2">
+      ${components.map(
+        (name) => html`<li key=${name} className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-slate-100">${name}</li>`,
+      )}
+    </ul>
+  `;
+}

--- a/templates/agent-project/frontend/index.html
+++ b/templates/agent-project/frontend/index.html
@@ -3,51 +3,36 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AgentCore // Terminal</title>
+    <title>AgentCore // Dashboard Kit</title>
+    <script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Sora', 'system-ui', 'sans-serif'],
+                        mono: ['IBM Plex Mono', 'monospace']
+                    },
+                    boxShadow: {
+                        panel: '0 18px 60px rgba(2, 6, 23, 0.35)'
+                    }
+                }
+            }
+        };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Sora:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="style.css" rel="stylesheet">
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap');
-        body { font-family: 'Fira Code', monospace; }
-    </style>
 </head>
-<body class="bg-black text-green-500 h-screen w-screen overflow-hidden flex flex-col p-4 crt">
-
-    <!-- Header -->
-    <header class="flex justify-between border-b border-green-800 pb-2 mb-4">
-        <div>
-            <h1 class="text-xl font-bold">AGENT_CORE v2.0</h1>
-            <p class="text-xs text-green-700">SECURE CONNECTION ESTABLISHED</p>
+<body class="dashboard-shell font-sans antialiased">
+    <div id="app"></div>
+    <noscript>
+        <div style="padding: 1rem; color: #fff; background: #0f172a; font-family: sans-serif;">
+            This frontend requires JavaScript to render the React component library.
         </div>
-        <div id="status" class="text-right">
-            <span class="text-red-500 blink">DISCONNECTED</span>
-        </div>
-    </header>
-
-    <!-- Chat Output -->
-    <main id="chat-window" class="flex-grow overflow-y-auto mb-4 space-y-2 p-2 scrollbar-hide">
-        <div class="text-green-800">System initialization...</div>
-        <div class="text-green-800">Loading neural interfaces...</div>
-        <div class="text-green-500">Welcome, Operator. Authentication required.</div>
-    </main>
-
-    <!-- Input Area -->
-    <footer class="border-t border-green-800 pt-2">
-        <div id="auth-panel" class="hidden">
-            <button onclick="login()" class="border border-green-500 px-4 py-2 hover:bg-green-900 transition w-full text-left">
-                > INITIATE_OAUTH_SEQUENCE()
-            </button>
-        </div>
-
-        <form id="chat-form" class="hidden flex gap-2" onsubmit="sendMessage(event)">
-            <span class="pt-2">></span>
-            <input type="text" id="prompt"
-                class="bg-black border-none outline-none flex-grow text-green-400 focus:ring-0"
-                placeholder="Enter command..." autocomplete="off">
-            <button type="submit" class="text-xs border border-green-800 px-2 hover:bg-green-900">EXEC</button>
-        </form>
-    </footer>
-
-    <script src="app.js"></script>
+    </noscript>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/templates/agent-project/frontend/style.css
+++ b/templates/agent-project/frontend/style.css
@@ -1,30 +1,95 @@
-.crt::before {
-    content: " ";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.25) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.06), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.06));
-    z-index: 2;
-    background-size: 100% 2px, 3px 100%;
+:root {
+    color-scheme: dark;
+    --bg-1: #020617;
+    --bg-2: #111827;
+    --bg-3: #1e293b;
+    --glow-a: rgba(56, 189, 248, 0.14);
+    --glow-b: rgba(16, 185, 129, 0.12);
+    --glow-c: rgba(244, 114, 182, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+    min-height: 100%;
+}
+
+body {
+    margin: 0;
+    background:
+        radial-gradient(circle at 12% 14%, var(--glow-a), transparent 42%),
+        radial-gradient(circle at 88% 12%, var(--glow-b), transparent 46%),
+        radial-gradient(circle at 50% 100%, var(--glow-c), transparent 45%),
+        linear-gradient(160deg, var(--bg-1), var(--bg-2) 55%, var(--bg-3));
+    background-attachment: fixed;
+}
+
+.dashboard-shell {
+    position: relative;
+}
+
+.dashboard-shell::before {
+    content: "";
+    position: fixed;
+    inset: 0;
     pointer-events: none;
+    opacity: 0.35;
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 28px 28px;
+    mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
 }
 
-.blink {
-    animation: blinker 1s linear infinite;
+.glass-panel {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.68));
+    backdrop-filter: blur(14px);
+    box-shadow: 0 18px 60px rgba(2, 6, 23, 0.35);
 }
 
-@keyframes blinker {
-    50% { opacity: 0; }
+pre,
+code,
+textarea {
+    font-family: "IBM Plex Mono", monospace;
 }
 
-/* Custom Scrollbar */
-.scrollbar-hide::-webkit-scrollbar {
-    display: none;
+pre {
+    margin: 0;
 }
-.scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+
+/* Scrollbars */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.35) rgba(15, 23, 42, 0.25);
+}
+
+*::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+*::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    background-color: rgba(148, 163, 184, 0.35);
+}
+
+*::-webkit-scrollbar-track {
+    background: rgba(15, 23, 42, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }


### PR DESCRIPTION
## Summary
- add a reusable React/Tailwind (no-bundler) frontend component library for AgentCore dashboard UIs
- refactor the template frontend and `examples/5-integrated` frontend to use the new shared component primitives
- document the component-library workflow and OpenAPI-driven tool catalog integration in repo docs

## Validation
- `make preflight-session` (PASS, run at start and again before commit/push)
- `node --check templates/agent-project/frontend/app.js`
- `node --check templates/agent-project/frontend/components.js`
- `node --check examples/5-integrated/frontend/app.js`
- `node --check examples/5-integrated/frontend/components.js`
- `diff -qr templates/agent-project/frontend examples/5-integrated/frontend` (PASS)
- `pre-commit run --files README.md DEVELOPER_GUIDE.md examples/5-integrated/README.md templates/agent-project/frontend/index.html templates/agent-project/frontend/app.js templates/agent-project/frontend/style.css templates/agent-project/frontend/components.js examples/5-integrated/frontend/index.html examples/5-integrated/frontend/app.js examples/5-integrated/frontend/style.css examples/5-integrated/frontend/components.js` (PASS after one auto-fix rerun)

Closes #34
