### PR TITLE
#48 Harden CloudFront SPA/API behavior split in BFF distribution

### DIFF
--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -5,6 +5,7 @@ This module implements the **Serverless Token Handler Pattern** (ADR 0011) to se
 ## Architecture
 
 *   **Frontend**: S3 + CloudFront (SPA Hosting).
+    CloudFront rewrites extension-less SPA routes to `/index.html` at viewer-request time, while preserving `/api/*` and `/auth/*` origin status codes.
 *   **API**: Amazon API Gateway (REST).
 *   **Auth**: "Token Handler" Lambdas (Login/Callback) + DynamoDB Session Store.
     The request authorizer validates the session cookie against the stored session record and JWT tenant claims before allowing `/api/*` calls.
@@ -80,3 +81,7 @@ Useful outputs:
 ### 4. CORS Errors
 *   **Cause**: API Gateway not returning CORS headers.
 *   **Fix**: The module assumes CloudFront proxies everything (`/api/*`). Ensure you are accessing via the CloudFront URL, not the API Gateway URL directly (which has different origin).
+
+### 5. API 4xx Returning `index.html` (Regression Guard)
+*   **Cause**: Misconfigured CloudFront SPA fallback using distribution-wide `custom_error_response`.
+*   **Fix**: Keep SPA fallback on the default S3 behavior via the viewer-request CloudFront Function (`spa_route_rewrite`). Do not use distribution-wide `403/404 -> /index.html` rewrites.


### PR DESCRIPTION
Closes #48

## Summary
- move SPA deep-link fallback from distribution-wide CloudFront custom error rewrites to a viewer-request CloudFront Function on the default S3 behavior
- preserve `/api/*` and `/auth/*` origin 4xx/5xx status codes instead of rewriting them to `index.html`
- add static validation coverage for the hardened split behavior and document the regression guard in the BFF module README

## Validation
- `terraform -chdir=terraform fmt modules/agentcore-bff/cloudfront.tf`
- `terraform -chdir=terraform fmt -check -recursive` ✅
- `python3 terraform/tests/validation/test_senior_remediation.py` ✅
- `terraform -chdir=terraform init -backend=false` ✅
- `terraform -chdir=terraform validate` ✅
- `make preflight-session` (start and pre-commit/push) ✅
