### PR TITLE
B3: add CI policy/tag conformance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Ensure generated OpenAPI artifact is committed
         run: git diff --exit-code -- docs/api/mcp-tools-v1.openapi.json
 
+  governance-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Canonical tag conformance
+        run: bash terraform/tests/validation/tags_test.sh
+      - name: IAM wildcard exception documentation conformance
+        run: python3 terraform/tests/validation/policy_wildcard_exceptions_test.py
+
   terraform-validate:
     runs-on: ubuntu-latest
     steps:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -156,6 +156,10 @@ checkov -d . --framework terraform --compact --config-file .checkov.yaml
 
 # Lint
 tflint --recursive
+
+# Governance conformance (tags + wildcard policy exceptions)
+bash tests/validation/tags_test.sh
+python3 tests/validation/policy_wildcard_exceptions_test.py
 ```
 
 **Key Point**: You can validate everything locally without an AWS account!

--- a/terraform/tests/validation/policy_wildcard_exceptions_test.py
+++ b/terraform/tests/validation/policy_wildcard_exceptions_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Conformance check for IAM wildcard resource exceptions.
+
+This script enforces repo policy for `Resource = "*"` in Terraform:
+- New wildcard resources must be explicitly reviewed (count/classification check).
+- AWS-required wildcard exceptions must include an `AWS-REQUIRED:` comment.
+- The workload identity wildcard must remain ABAC-scoped and documented.
+
+Runs with stdlib only (no pytest dependency required).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+EXPECTED_COUNTS = {
+    "ec2_network_interface": 2,
+    "logs_put_resource_policy": 1,
+    "bedrock_abac_scoped": 1,
+}
+
+WINDOW_LINES = 25
+WILDCARD_RE = re.compile(r'Resource\s*=\s*"\*"')
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def classify_wildcard(window_text: str) -> str | None:
+    if '"ec2:CreateNetworkInterface"' in window_text:
+        return "ec2_network_interface"
+    if '"logs:PutResourcePolicy"' in window_text:
+        return "logs_put_resource_policy"
+    if '"bedrock:*"' in window_text:
+        return "bedrock_abac_scoped"
+    return None
+
+
+def validate_documentation(
+    classification: str, window_text: str, rel_path: str, line_no: int, errors: list[str]
+) -> None:
+    prefix = f"{rel_path}:{line_no}"
+    if classification == "ec2_network_interface":
+        expected_comment = "# AWS-REQUIRED: EC2 network interface APIs do not support resource-level scoping."
+        if expected_comment not in window_text:
+            errors.append(f"{prefix}: missing required wildcard exception comment ({expected_comment})")
+        return
+
+    if classification == "logs_put_resource_policy":
+        expected_comment = "# AWS-REQUIRED: logs:PutResourcePolicy does not support resource-level scoping"
+        if expected_comment not in window_text:
+            errors.append(f"{prefix}: missing required wildcard exception comment ({expected_comment})")
+        return
+
+    if classification == "bedrock_abac_scoped":
+        if "# Rule 7.2: Resource-level ABAC" not in window_text:
+            errors.append(f"{prefix}: missing ABAC rationale comment for workload identity wildcard")
+        if '"aws:ResourceTag/Project"' not in window_text:
+            errors.append(f"{prefix}: workload identity wildcard missing ABAC tag condition")
+        return
+
+    errors.append(f"{prefix}: unhandled wildcard classification {classification}")
+
+
+def main() -> int:
+    root = repo_root()
+    terraform_dir = root / "terraform"
+    if not terraform_dir.exists():
+        print(f"ERROR: Terraform directory not found: {terraform_dir}")
+        return 1
+
+    findings: list[tuple[str, int, str]] = []
+    errors: list[str] = []
+
+    for tf_file in sorted(terraform_dir.rglob("*.tf")):
+        if ".terraform" in tf_file.parts:
+            continue
+        rel_path = tf_file.relative_to(root).as_posix()
+        lines = tf_file.read_text(encoding="utf-8").splitlines()
+        for idx, line in enumerate(lines):
+            if not WILDCARD_RE.search(line):
+                continue
+            start = max(0, idx - WINDOW_LINES)
+            end = min(len(lines), idx + WINDOW_LINES + 1)
+            window_text = "\n".join(lines[start:end])
+            classification = classify_wildcard(window_text)
+            line_no = idx + 1
+            if classification is None:
+                errors.append(f'{rel_path}:{line_no}: wildcard Resource="*" is not an approved/documented exception')
+                continue
+            findings.append((rel_path, line_no, classification))
+            validate_documentation(classification, window_text, rel_path, line_no, errors)
+
+    counts = Counter(classification for _, _, classification in findings)
+    total_expected = sum(EXPECTED_COUNTS.values())
+
+    print("==========================================")
+    print("IAM Wildcard Exception Conformance Check")
+    print("==========================================")
+    for rel_path, line_no, classification in findings:
+        print(f"  FOUND: {rel_path}:{line_no} -> {classification}")
+
+    if len(findings) != total_expected:
+        errors.append(
+            f'Expected {total_expected} wildcard Resource="*" statements, found {len(findings)}. '
+            "Review/test update required for policy exception changes."
+        )
+
+    for classification, expected_count in EXPECTED_COUNTS.items():
+        actual_count = counts.get(classification, 0)
+        if actual_count != expected_count:
+            errors.append(
+                f"Expected {expected_count} '{classification}' wildcard exceptions, found {actual_count}. "
+                "Review/test update required."
+            )
+
+    print("")
+    print("Counts:")
+    for classification in sorted(EXPECTED_COUNTS):
+        print(f"  {classification}: {counts.get(classification, 0)}")
+
+    if errors:
+        print("")
+        print("FAIL:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print("")
+    print('PASS: All wildcard Resource="*" usages are approved and documented.')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/tests/validation/tags_test.sh
+++ b/terraform/tests/validation/tags_test.sh
@@ -9,7 +9,7 @@
 # Usage: bash terraform/tests/validation/tags_test.sh
 # Requires: no AWS credentials, no terraform init needed.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -55,6 +55,7 @@ echo ""
 echo "--- versions.tf: provider default_tags ---"
 VERSIONS="$TERRAFORM_DIR/versions.tf"
 check "provider default_tags AppID"    "AppID"   "$VERSIONS"
+check "provider default_tags Environment" "Environment" "$VERSIONS"
 check "provider default_tags AgentName" "AgentName" "$VERSIONS"
 check "provider default_tags ManagedBy" "ManagedBy" "$VERSIONS"
 check "provider default_tags Owner"    "Owner"   "$VERSIONS"
@@ -72,7 +73,8 @@ else
 fi
 
 # Verify no bare var.tags left in module arguments (only in locals merge, which is expected)
-RAW_TAG_MODULE_REFS=$(grep -n "tags\s*=\s*var\.tags" "$MAIN" 2>/dev/null | wc -l || echo 0)
+RAW_TAG_MODULE_REFS=$(grep -c "tags\s*=\s*var\.tags" "$MAIN" 2>/dev/null || true)
+RAW_TAG_MODULE_REFS="${RAW_TAG_MODULE_REFS:-0}"
 if [ "$RAW_TAG_MODULE_REFS" -eq 0 ]; then
   echo "  PASS: No bare 'tags = var.tags' in module calls (all use canonical_tags)"
   PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary
- add a CI governance-conformance job for canonical tag and wildcard-policy exception checks
- add a stdlib-only wildcard exception conformance test for Terraform IAM Resource="*" statements
- tighten the tag taxonomy test and document local conformance commands in the developer guide

## Validation
- ==========================================
Canonical Tag Taxonomy Validation
==========================================

--- locals.tf: canonical_tags local ---
  PASS: canonical_tags local defined
  PASS: AppID key present
  PASS: Environment key present
  PASS: AgentName key present
  PASS: ManagedBy key present
  PASS: Owner key present

--- variables.tf: owner variable ---
  PASS: owner variable declared

--- versions.tf: provider default_tags ---
  PASS: provider default_tags AppID
  PASS: provider default_tags Environment
  PASS: provider default_tags AgentName
  PASS: provider default_tags ManagedBy
  PASS: provider default_tags Owner

--- main.tf: canonical_tags passed to all modules ---
  PASS: canonical_tags used in 6 module calls (>= 5 required)
  PASS: No bare 'tags = var.tags' in module calls (all use canonical_tags)

==========================================
Results: 14 passed, 0 failed
==========================================
PASS (PASS)
- ==========================================
IAM Wildcard Exception Conformance Check
==========================================
  FOUND: terraform/modules/agentcore-foundation/gateway.tf:100 -> logs_put_resource_policy
  FOUND: terraform/modules/agentcore-foundation/iam.tf:164 -> bedrock_abac_scoped
  FOUND: terraform/modules/agentcore-tools/iam.tf:81 -> ec2_network_interface
  FOUND: terraform/modules/agentcore-tools/iam.tf:173 -> ec2_network_interface

Counts:
  bedrock_abac_scoped: 1
  ec2_network_interface: 2
  logs_put_resource_policy: 1

PASS: All wildcard Resource="*" usages are approved and documented. (PASS)
- Terraform Format.....................................(no files to check)Skipped
Terraform Validate...................................(no files to check)Skipped
Terraform Docs.......................................(no files to check)Skipped
TFLint...............................................(no files to check)Skipped
Checkov Security Scan................................(no files to check)Skipped
Check YAML...............................................................Passed
Check JSON...........................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Check Large Files........................................................Passed
Check Merge Conflicts....................................................Passed
Detect Private Keys......................................................Passed
Black Formatter..........................................................Passed
Flake8 Linter............................................................Passed
Check Docs Updated With Code.............................................Passed
Check Tests Updated With Terraform Changes...............................Passed
Check Agent Rule Docs In Sync............................................Passed
Block .scratch Commits...................................................Passed
Prevent File Proliferation...............................................Passed
Check No Placeholder ARNs................................................Passed (PASS)
- make[1]: Entering directory '/mnt/c/Users/julia/worktrees/wt25'
bash /mnt/c/Users/julia/worktrees/wt25/terraform/scripts/session/preflight_startup.sh
Preflight context:
  repo:       /mnt/c/Users/julia/worktrees/wt25
  path:       /mnt/c/Users/julia/worktrees/wt25
  worktree:   /mnt/c/Users/julia/worktrees/wt25
  primary:    /mnt/c/Users/julia/terraform
  branch:     wt/governance/25-add-ci-policy-tag-conformance-checks-execution-ready-b-b3-ex
Preflight result: PASS
make[1]: Leaving directory '/mnt/c/Users/julia/worktrees/wt25' before commit/push (PASS)

Closes #25