### PR TITLE
feat: add custom domain and ACM certificate support for BFF CloudFront #53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Custom domain and ACM certificate support for the BFF CloudFront distribution (Issue #53).
 - MCP Tools OpenAPI 3.1.0 specification generation from the tool registry in `examples/mcp-servers/` (Issue #33).
 - New `make generate-openapi` target in root `Makefile` to update the specification file at `docs/api/mcp-tools-v1.openapi.json`.
 - Resource Coverage Matrix (`docs/NOVATION_MATRIX.md`) identifying migration candidates from CLI to native Terraform (Issue #17).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -181,6 +181,8 @@ module "agentcore_bff" {
 
   oidc_client_id             = var.oidc_client_id
   oidc_client_secret_arn     = var.oidc_client_secret_arn
+  custom_domain_name         = var.bff_custom_domain_name
+  acm_certificate_arn        = var.bff_acm_certificate_arn
   logging_bucket_id          = module.agentcore_foundation.access_logs_bucket_id
   reserved_concurrency       = var.proxy_reserved_concurrency
   waf_acl_arn                = module.agentcore_foundation.waf_acl_arn

--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -90,6 +90,31 @@ module "agentcore_bff" {
 
 The harness default is `cloudfront_waf_acl_arn = ""` (WAF disabled on CloudFront).
 
+## Custom Domains & SSL (Issue #53)
+
+Enterprise deployments can configure a custom domain name (e.g., `agent.example.com`) for the BFF CloudFront distribution. This requires providing an ACM certificate ARN.
+
+### Constraints
+
+- The ACM certificate **must** be created in `us-east-1`. CloudFront only accepts certificates from this region for global distributions.
+- You must separately configure a DNS record (e.g., CNAME in Route 53 or your DNS provider) pointing the custom domain to the CloudFront distribution's domain name.
+- The `spa_url` output will reflect the custom domain if configured.
+
+### Usage
+
+```hcl
+module "agentcore_bff" {
+  source = "./modules/agentcore-bff"
+
+  enable_bff = true
+  # ... other required variables ...
+
+  # Optional: custom domain and ACM certificate
+  custom_domain_name  = "agent.example.com"
+  acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abc12345-def6-7890-ghij-klmnopqrstuv"
+}
+```
+
 ### Operational Considerations
 
 | Topic | Guidance |

--- a/terraform/modules/agentcore-bff/cloudfront.tf
+++ b/terraform/modules/agentcore-bff/cloudfront.tf
@@ -77,6 +77,8 @@ resource "aws_cloudfront_distribution" "bff" {
   # Optional WAFv2 CLOUDFRONT-scope Web ACL association (must be in us-east-1)
   web_acl_id = var.cloudfront_waf_acl_arn != "" ? var.cloudfront_waf_acl_arn : null
 
+  aliases = var.custom_domain_name != "" ? [var.custom_domain_name] : []
+
   origin {
     domain_name              = aws_s3_bucket.spa[0].bucket_regional_domain_name
     origin_access_control_id = aws_cloudfront_origin_access_control.spa[0].id
@@ -184,7 +186,10 @@ resource "aws_cloudfront_distribution" "bff" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = var.acm_certificate_arn == ""
+    acm_certificate_arn            = var.acm_certificate_arn != "" ? var.acm_certificate_arn : null
+    ssl_support_method             = var.acm_certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.acm_certificate_arn != "" ? "TLSv1.2_2021" : "TLSv1"
   }
 
   tags = var.tags

--- a/terraform/modules/agentcore-bff/outputs.tf
+++ b/terraform/modules/agentcore-bff/outputs.tf
@@ -1,6 +1,6 @@
 output "spa_url" {
-  description = "URL of the SPA (CloudFront)"
-  value       = var.enable_bff ? "https://${aws_cloudfront_distribution.bff[0].domain_name}" : ""
+  description = "URL of the SPA (CloudFront or Custom Domain)"
+  value       = var.enable_bff ? (var.custom_domain_name != "" ? "https://${var.custom_domain_name}" : "https://${aws_cloudfront_distribution.bff[0].domain_name}") : ""
 }
 
 output "api_url" {

--- a/terraform/modules/agentcore-bff/variables.tf
+++ b/terraform/modules/agentcore-bff/variables.tf
@@ -116,6 +116,18 @@ variable "waf_acl_arn" {
   default     = ""
 }
 
+variable "custom_domain_name" {
+  description = "Custom domain name for the CloudFront distribution"
+  type        = string
+  default     = ""
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM Certificate ARN for the custom domain (must be in us-east-1)"
+  type        = string
+  default     = ""
+}
+
 variable "cloudfront_waf_acl_arn" {
   description = "ARN of a WAFv2 Web ACL (CLOUDFRONT scope, must be in us-east-1) to associate with the CloudFront distribution. Leave empty to disable WAF on CloudFront (default). Required format: arn:aws:wafv2:us-east-1:<account>:global/webacl/<name>/<id>."
   type        = string

--- a/terraform/variables_bff.tf
+++ b/terraform/variables_bff.tf
@@ -42,6 +42,22 @@ variable "oidc_client_secret_arn" {
   default     = ""
 }
 
+variable "bff_custom_domain_name" {
+  description = "Custom domain name for the BFF CloudFront distribution (e.g., agent.example.com). Requires bff_acm_certificate_arn."
+  type        = string
+  default     = ""
+}
+
+variable "bff_acm_certificate_arn" {
+  description = "ARN of the ACM certificate for the custom domain. Must be in us-east-1 for CloudFront."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.bff_acm_certificate_arn == "" || can(regex("^arn:aws:acm:us-east-1:[0-9]{12}:certificate/[a-f0-9-]+$", var.bff_acm_certificate_arn))
+    error_message = "bff_acm_certificate_arn must be in us-east-1 for CloudFront."
+  }
+}
+
 variable "bff_agentcore_runtime_arn" {
   description = "AgentCore runtime ARN for the BFF proxy (required if enable_bff is true and enable_runtime is false)"
   type        = string


### PR DESCRIPTION
Closes #53. Added support for custom domains and ACM certificates to the BFF CloudFront distribution. Updated root and module variables, and CloudFront configuration.