### PR TITLE
feat: support cross-account gateway/runtime invocation wiring

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -353,6 +353,11 @@ mcp_targets = {
 }
 ```
 
+Cross-account gateway target pattern (least privilege):
+- The foundation module scopes gateway-role `lambda:InvokeFunction` to the exact `mcp_targets[*].lambda_arn` values.
+- If the target Lambda is in another account, add a resource-based policy on that Lambda for the gateway service role ARN (`agentcore_gateway_role_arn` output from the root module).
+- If BFF invokes a runtime in another account, set both `bff_agentcore_runtime_arn` and `bff_agentcore_runtime_role_arn`.
+
 ### Tools Module
 
 Controls: Code Interpreter, Browser

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -179,14 +179,16 @@ module "agentcore_bff" {
 
   oidc_token_endpoint = var.oidc_token_endpoint != "" ? var.oidc_token_endpoint : try(local.oidc_discovery.token_endpoint, "")
 
-  oidc_client_id             = var.oidc_client_id
-  oidc_client_secret_arn     = var.oidc_client_secret_arn
-  custom_domain_name         = var.bff_custom_domain_name
-  acm_certificate_arn        = var.bff_acm_certificate_arn
-  logging_bucket_id          = module.agentcore_foundation.access_logs_bucket_id
-  reserved_concurrency       = var.proxy_reserved_concurrency
-  waf_acl_arn                = module.agentcore_foundation.waf_acl_arn
-  agentcore_runtime_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.agent_name}-runtime-role-${var.environment}"
+  oidc_client_id         = var.oidc_client_id
+  oidc_client_secret_arn = var.oidc_client_secret_arn
+  custom_domain_name     = var.bff_custom_domain_name
+  acm_certificate_arn    = var.bff_acm_certificate_arn
+  logging_bucket_id      = module.agentcore_foundation.access_logs_bucket_id
+  reserved_concurrency   = var.proxy_reserved_concurrency
+  waf_acl_arn            = module.agentcore_foundation.waf_acl_arn
+  agentcore_runtime_role_arn = var.bff_agentcore_runtime_role_arn != "" ? var.bff_agentcore_runtime_role_arn : (
+    var.enable_runtime ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.agent_name}-runtime-role-${var.environment}" : ""
+  )
 
   # Integration
   agentcore_runtime_arn = var.bff_agentcore_runtime_arn != "" ? var.bff_agentcore_runtime_arn : module.agentcore_runtime.runtime_arn

--- a/terraform/modules/agentcore-foundation/README.md
+++ b/terraform/modules/agentcore-foundation/README.md
@@ -12,6 +12,12 @@ This module manages the base infrastructure for a Bedrock Agent, including the M
 - `region`: AgentCore control-plane region for gateway/identity/observability resources.
 - `bedrock_region`: Optional Bedrock region override for model invocation permissions (defaults to `region`).
 
+## Cross-Account Lambda Targets (Gateway)
+
+- The gateway service role policy includes least-privilege `lambda:InvokeFunction` access scoped to configured `mcp_targets[*].lambda_arn`.
+- For Lambda targets in a different AWS account, add a resource-based policy on the target Lambda that allows the gateway service role ARN to invoke it.
+- `gateway_role_arn` output returns the effective gateway role ARN (created role or the externally supplied `gateway_role_arn`) so it can be used when wiring target-account policies.
+
 ## Known Failure Modes (Rule 16)
 
 ### 1. Partial Provisioning (CLI Timeout)

--- a/terraform/modules/agentcore-foundation/outputs.tf
+++ b/terraform/modules/agentcore-foundation/outputs.tf
@@ -16,7 +16,7 @@ output "gateway_endpoint" {
 
 output "gateway_role_arn" {
   description = "IAM role ARN for the gateway"
-  value       = var.enable_gateway ? aws_iam_role.gateway[0].arn : null
+  value       = var.enable_gateway ? (var.gateway_role_arn != "" ? var.gateway_role_arn : aws_iam_role.gateway[0].arn) : null
   sensitive   = true
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -48,3 +48,15 @@ output "agentcore_runtime_arn" {
   value       = module.agentcore_runtime.runtime_arn
   sensitive   = true
 }
+
+output "agentcore_gateway_arn" {
+  description = "AgentCore gateway ARN (useful for cross-account target policies)"
+  value       = module.agentcore_foundation.gateway_arn
+  sensitive   = true
+}
+
+output "agentcore_gateway_role_arn" {
+  description = "AgentCore gateway service role ARN (useful for cross-account Lambda resource policies)"
+  value       = module.agentcore_foundation.gateway_role_arn
+  sensitive   = true
+}

--- a/terraform/tests/validation/test_cross_account_gateway_support.py
+++ b/terraform/tests/validation/test_cross_account_gateway_support.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_foundation_gateway_role_invoke_permissions_are_least_privilege():
+    content = _read("terraform/modules/agentcore-foundation/iam.tf")
+
+    assert '"lambda:InvokeFunction"' in content
+    assert "gateway_target_lambda_arns" in content
+    assert "Resource = local.gateway_target_lambda_arns" in content
+
+    lambda_block_start = content.index('"lambda:InvokeFunction"')
+    lambda_block_window = content[max(0, lambda_block_start - 300) : lambda_block_start + 500]
+    assert 'Resource = "*"' not in lambda_block_window, "Lambda invoke statement must not use wildcard resources"
+
+
+def test_root_supports_explicit_bff_runtime_role_override_for_cross_account():
+    main_tf = _read("terraform/main.tf")
+    vars_bff_tf = _read("terraform/variables_bff.tf")
+
+    assert 'var.bff_agentcore_runtime_role_arn != ""' in main_tf
+    assert 'variable "bff_agentcore_runtime_role_arn"' in vars_bff_tf
+    assert "valid IAM role ARN" in vars_bff_tf
+
+
+def test_root_exposes_gateway_outputs_for_cross_account_policy_wiring():
+    outputs_tf = _read("terraform/outputs.tf")
+
+    assert 'output "agentcore_gateway_arn"' in outputs_tf
+    assert 'output "agentcore_gateway_role_arn"' in outputs_tf

--- a/terraform/variables_bff.tf
+++ b/terraform/variables_bff.tf
@@ -68,3 +68,16 @@ variable "bff_agentcore_runtime_arn" {
     error_message = "bff_agentcore_runtime_arn must be set when enable_bff is true and enable_runtime is false."
   }
 }
+
+variable "bff_agentcore_runtime_role_arn" {
+  description = "Optional runtime IAM role ARN for the BFF proxy to assume (set for cross-account runtime identity propagation)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition = var.bff_agentcore_runtime_role_arn == "" || can(
+      regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.bff_agentcore_runtime_role_arn)
+    )
+    error_message = "bff_agentcore_runtime_role_arn must be empty or a valid IAM role ARN."
+  }
+}


### PR DESCRIPTION
## Summary
- add least-privilege gateway service-role `lambda:InvokeFunction` permissions scoped to configured `mcp_targets[*].lambda_arn`
- expose effective gateway role ARN for cross-account Lambda target policy wiring (including externally supplied gateway role)
- add root BFF runtime-role override (`bff_agentcore_runtime_role_arn`) and remove hardcoded same-account assumption when runtime is external
- add root outputs for gateway ARN + gateway role ARN and document the cross-account gateway/BFF runtime pattern
- add validation test coverage for cross-account gateway support wiring and no-wildcard lambda invoke policy

## Validation
- `make preflight-session` ✅ (run at session start and again before commit/push)
- `terraform -chdir=terraform fmt -recursive` ✅
- `terraform -chdir=terraform fmt -check -recursive` ✅
- `python3 -m pytest -q terraform/tests/validation/test_cross_account_gateway_support.py` ✅ (`3 passed`)
- `python3 terraform/tests/validation/policy_wildcard_exceptions_test.py` ✅
- `python3 -m pytest -q terraform/tests/validation/test_remediation_integrity.py` ✅ (`6 passed`)
- `terraform -chdir=terraform init -backend=false -input=false` ✅
- `terraform -chdir=terraform validate` ✅
- `terraform -chdir=terraform plan -input=false -var-file=../examples/research-agent.tfvars` ⚠️ failed in local env (no AWS credentials configured)
- `checkov -d terraform --framework terraform --compact --config-file terraform/.checkov.yaml` ✅
- `tflint --recursive --config /mnt/c/Users/julia/worktrees/wt31/terraform/.tflint.hcl` ✅ (version-compatible invocation)
- `pre-commit run --files ...` (issue-31 changed files) ✅
- `pre-commit run --all-files` ⚠️ repo-wide failure in `terraform_validate` for `examples/5-integrated` due conflicting provider constraints (`~> 5.80` and `~> 6.33.0`) unrelated to this change; hooks for the issue-31 file set passed

## Issue
Closes #31
