### PR TITLE
feat: agent-level CloudWatch dashboards + inference-profile cost isolation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ Notes:
 | `log_retention_days` | `number` | `30` | CloudWatch log retention period. |
 | `enable_xray` | `bool` | `true` | Enable X-Ray distributed tracing. |
 | `alarm_sns_topic_arn` | `string` | `""` | SNS topic for CloudWatch alarm notifications. |
+| `enable_agent_dashboards` | `bool` | `false` | Create an optional per-agent CloudWatch dashboard (Terraform-managed). |
+| `agent_dashboard_name` | `string` | `""` | Optional dashboard name override (defaults to `<agent_name>-dashboard` when empty). |
+| `dashboard_region` | `string` | `""` | Optional widget/console region override (defaults to `region` when empty). |
+| `dashboard_widgets_override` | `string` | `""` | Optional JSON array string of CloudWatch widget objects to replace the default dashboard layout. |
 | `enable_waf` | `bool` | `false` | Enable WAF protection for API Gateway. |
 | `enable_kms` | `bool` | `false` | Enable customer-managed KMS encryption. |
 | `kms_key_arn` | `string` | `""` | KMS key ARN (required when `enable_kms` is true). |
@@ -411,6 +415,33 @@ Notes:
 | `enable_inference_profile` | `bool` | `false` | Enable Bedrock application inference profile. |
 | `inference_profile_name` | `string` | `""` | Name for the inference profile. |
 | `inference_profile_model_source_arn` | `string` | `""` | Foundation model or system-defined inference profile ARN. |
+
+### Per-Agent Dashboards (Issue #10)
+
+Set `enable_agent_dashboards = true` to create a Terraform-managed CloudWatch dashboard in the foundation module. The default dashboard includes:
+
+- Gateway metrics (`Errors`, `TargetInvocationDuration`) when the gateway is enabled
+- Log widgets for gateway/runtime and optional component logs (code interpreter, browser, evaluator) based on enabled features
+
+If a service does not emit a stable CloudWatch metric for a desired panel (for example runtime/tool invocation counts in some deployments), the default dashboard omits that metric widget and relies on log widgets instead. Use `dashboard_widgets_override` for advanced custom layouts.
+
+### Inference Profile Cost Isolation (Per Agent)
+
+For Bedrock usage/cost attribution per agent, enable `enable_inference_profile` and use the created **application inference profile ARN as `modelId`** in runtime/evaluator calls.
+
+Example runtime config:
+
+```hcl
+runtime_config = {
+  modelId = module.agentcore_runtime.inference_profile_arn
+}
+```
+
+Operational verification points:
+
+- Terraform output `agentcore_inference_profile_arn` (or `module.agentcore_runtime.inference_profile_arn`) confirms the profile ARN to wire into `modelId`.
+- Terraform output `agentcore_dashboard_console_url` opens the per-agent CloudWatch dashboard for operational correlation (errors/latency/logs).
+- AWS billing/usage tooling (for example Cost Explorer and Bedrock usage reporting) should be inspected using the inference-profile-based calling pattern above to attribute usage to the agent-specific profile.
 
 ### Governance
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,8 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.33.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | ~> 3.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.33.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
 
 ## Modules
 
@@ -37,12 +37,16 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agent_dashboard_name"></a> [agent\_dashboard\_name](#input\_agent\_dashboard\_name) | Optional CloudWatch dashboard name override (defaults to <agent\_name>-dashboard when empty) | `string` | `""` | no |
 | <a name="input_agent_name"></a> [agent\_name](#input\_agent\_name) | Name of the agent | `string` | n/a | yes |
 | <a name="input_agentcore_region"></a> [agentcore\_region](#input\_agentcore\_region) | Optional AgentCore control-plane region override (defaults to region) | `string` | `""` | no |
 | <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | Optional SNS topic ARN for CloudWatch alarm notifications | `string` | `""` | no |
 | <a name="input_app_id"></a> [app\_id](#input\_app\_id) | Application ID for multi-tenant isolation (North anchor). Defaults to agent\_name. | `string` | `""` | no |
 | <a name="input_bedrock_region"></a> [bedrock\_region](#input\_bedrock\_region) | Optional Bedrock region override for model-related resources (defaults to agentcore\_region) | `string` | `""` | no |
+| <a name="input_bff_acm_certificate_arn"></a> [bff\_acm\_certificate\_arn](#input\_bff\_acm\_certificate\_arn) | ARN of the ACM certificate for the custom domain. Must be in us-east-1 for CloudFront. | `string` | `""` | no |
 | <a name="input_bff_agentcore_runtime_arn"></a> [bff\_agentcore\_runtime\_arn](#input\_bff\_agentcore\_runtime\_arn) | AgentCore runtime ARN for the BFF proxy (required if enable\_bff is true and enable\_runtime is false) | `string` | `""` | no |
+| <a name="input_bff_agentcore_runtime_role_arn"></a> [bff\_agentcore\_runtime\_role\_arn](#input\_bff\_agentcore\_runtime\_role\_arn) | Optional runtime IAM role ARN for the BFF proxy to assume (set for cross-account runtime identity propagation) | `string` | `""` | no |
+| <a name="input_bff_custom_domain_name"></a> [bff\_custom\_domain\_name](#input\_bff\_custom\_domain\_name) | Custom domain name for the BFF CloudFront distribution (e.g., agent.example.com). Requires bff\_acm\_certificate\_arn. | `string` | `""` | no |
 | <a name="input_bff_region"></a> [bff\_region](#input\_bff\_region) | Optional BFF/API Gateway region override (defaults to agentcore\_region) | `string` | `""` | no |
 | <a name="input_browser_network_mode"></a> [browser\_network\_mode](#input\_browser\_network\_mode) | Network mode for browser (PUBLIC, SANDBOX, VPC) | `string` | `"SANDBOX"` | no |
 | <a name="input_browser_recording_s3_bucket"></a> [browser\_recording\_s3\_bucket](#input\_browser\_recording\_s3\_bucket) | S3 bucket for browser session recordings | `string` | `""` | no |
@@ -50,8 +54,12 @@
 | <a name="input_cedar_policy_files"></a> [cedar\_policy\_files](#input\_cedar\_policy\_files) | Map of policy names to Cedar policy file paths | `map(string)` | `{}` | no |
 | <a name="input_code_interpreter_network_mode"></a> [code\_interpreter\_network\_mode](#input\_code\_interpreter\_network\_mode) | Network mode for code interpreter (PUBLIC, SANDBOX, VPC) | `string` | `"SANDBOX"` | no |
 | <a name="input_code_interpreter_vpc_config"></a> [code\_interpreter\_vpc\_config](#input\_code\_interpreter\_vpc\_config) | VPC configuration for code interpreter | <pre>object({<br/>    subnet_ids          = list(string)<br/>    security_group_ids  = list(string)<br/>    associate_public_ip = optional(bool, false)<br/>  })</pre> | `null` | no |
+| <a name="input_dashboard_region"></a> [dashboard\_region](#input\_dashboard\_region) | Optional dashboard widget/console region override (defaults to region when empty) | `string` | `""` | no |
+| <a name="input_dashboard_widgets_override"></a> [dashboard\_widgets\_override](#input\_dashboard\_widgets\_override) | Optional JSON array string of CloudWatch dashboard widgets to replace the default widget set | `string` | `""` | no |
 | <a name="input_deployment_bucket_name"></a> [deployment\_bucket\_name](#input\_deployment\_bucket\_name) | S3 bucket name for deployment artifacts | `string` | `""` | no |
+| <a name="input_enable_agent_dashboards"></a> [enable\_agent\_dashboards](#input\_enable\_agent\_dashboards) | Enable Terraform-managed per-agent CloudWatch dashboards | `bool` | `false` | no |
 | <a name="input_enable_bff"></a> [enable\_bff](#input\_enable\_bff) | Enable the Serverless SPA/BFF module | `bool` | `false` | no |
+| <a name="input_enable_bff_audit_log_persistence"></a> [enable\_bff\_audit\_log\_persistence](#input\_enable\_bff\_audit\_log\_persistence) | Persist BFF proxy shadow audit logs to S3 and provision Athena/Glue query resources | `bool` | `false` | no |
 | <a name="input_enable_browser"></a> [enable\_browser](#input\_enable\_browser) | Enable web browser tool | `bool` | `false` | no |
 | <a name="input_enable_browser_recording"></a> [enable\_browser\_recording](#input\_enable\_browser\_recording) | Enable session recording for browser | `bool` | `false` | no |
 | <a name="input_enable_code_interpreter"></a> [enable\_code\_interpreter](#input\_enable\_code\_interpreter) | Enable Python code interpreter | `bool` | `true` | no |
@@ -119,8 +127,17 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_agentcore_bff_api_url"></a> [agentcore\_bff\_api\_url](#output\_agentcore\_bff\_api\_url) | BFF API URL |
+| <a name="output_agentcore_bff_audit_logs_athena_database"></a> [agentcore\_bff\_audit\_logs\_athena\_database](#output\_agentcore\_bff\_audit\_logs\_athena\_database) | Athena/Glue database for BFF proxy audit logs |
+| <a name="output_agentcore_bff_audit_logs_athena_table"></a> [agentcore\_bff\_audit\_logs\_athena\_table](#output\_agentcore\_bff\_audit\_logs\_athena\_table) | Athena/Glue table for BFF proxy audit logs |
+| <a name="output_agentcore_bff_audit_logs_athena_workgroup"></a> [agentcore\_bff\_audit\_logs\_athena\_workgroup](#output\_agentcore\_bff\_audit\_logs\_athena\_workgroup) | Athena workgroup for BFF proxy audit logs |
+| <a name="output_agentcore_bff_audit_logs_s3_prefix"></a> [agentcore\_bff\_audit\_logs\_s3\_prefix](#output\_agentcore\_bff\_audit\_logs\_s3\_prefix) | S3 prefix for BFF proxy audit shadow JSON logs |
 | <a name="output_agentcore_bff_authorizer_id"></a> [agentcore\_bff\_authorizer\_id](#output\_agentcore\_bff\_authorizer\_id) | Authorizer ID |
 | <a name="output_agentcore_bff_rest_api_id"></a> [agentcore\_bff\_rest\_api\_id](#output\_agentcore\_bff\_rest\_api\_id) | REST API ID |
 | <a name="output_agentcore_bff_session_table_name"></a> [agentcore\_bff\_session\_table\_name](#output\_agentcore\_bff\_session\_table\_name) | DynamoDB Session Table |
 | <a name="output_agentcore_bff_spa_url"></a> [agentcore\_bff\_spa\_url](#output\_agentcore\_bff\_spa\_url) | SPA URL |
+| <a name="output_agentcore_dashboard_console_url"></a> [agentcore\_dashboard\_console\_url](#output\_agentcore\_dashboard\_console\_url) | CloudWatch console URL for the per-agent dashboard |
+| <a name="output_agentcore_dashboard_name"></a> [agentcore\_dashboard\_name](#output\_agentcore\_dashboard\_name) | CloudWatch dashboard name for per-agent observability |
+| <a name="output_agentcore_gateway_arn"></a> [agentcore\_gateway\_arn](#output\_agentcore\_gateway\_arn) | AgentCore gateway ARN (useful for cross-account target policies) |
+| <a name="output_agentcore_gateway_role_arn"></a> [agentcore\_gateway\_role\_arn](#output\_agentcore\_gateway\_role\_arn) | AgentCore gateway service role ARN (useful for cross-account Lambda resource policies) |
+| <a name="output_agentcore_inference_profile_arn"></a> [agentcore\_inference\_profile\_arn](#output\_agentcore\_inference\_profile\_arn) | Bedrock application inference profile ARN for per-agent cost isolation |
 | <a name="output_agentcore_runtime_arn"></a> [agentcore\_runtime\_arn](#output\_agentcore\_runtime\_arn) | AgentCore runtime ARN |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,11 +23,19 @@ module "agentcore_foundation" {
   oauth_return_urls = var.oauth_return_urls
 
   # Observability
-  enable_observability = var.enable_observability
-  log_retention_days   = var.log_retention_days
-  enable_xray          = var.enable_xray
-  alarm_sns_topic_arn  = var.alarm_sns_topic_arn
-  enable_waf           = var.enable_waf
+  enable_observability                    = var.enable_observability
+  log_retention_days                      = var.log_retention_days
+  enable_xray                             = var.enable_xray
+  alarm_sns_topic_arn                     = var.alarm_sns_topic_arn
+  enable_agent_dashboards                 = var.enable_agent_dashboards
+  agent_dashboard_name                    = var.agent_dashboard_name
+  dashboard_region                        = var.dashboard_region != "" ? var.dashboard_region : var.region
+  dashboard_widgets_override              = var.dashboard_widgets_override
+  dashboard_include_runtime_logs          = var.enable_runtime
+  dashboard_include_code_interpreter_logs = var.enable_code_interpreter
+  dashboard_include_browser_logs          = var.enable_browser
+  dashboard_include_evaluator_logs        = var.enable_evaluations
+  enable_waf                              = var.enable_waf
 
   # Encryption
   enable_kms  = var.enable_kms

--- a/terraform/modules/agentcore-foundation/outputs.tf
+++ b/terraform/modules/agentcore-foundation/outputs.tf
@@ -60,3 +60,18 @@ output "gateway_targets" {
   description = "Map of gateway target names (IDs available in .terraform/target_*.json)"
   value       = var.enable_gateway ? keys(var.mcp_targets) : []
 }
+
+output "agent_dashboard_name" {
+  description = "CloudWatch dashboard name for per-agent observability"
+  value       = var.enable_observability && var.enable_agent_dashboards ? aws_cloudwatch_dashboard.agent[0].dashboard_name : null
+}
+
+output "agent_dashboard_console_url" {
+  description = "CloudWatch console URL for the per-agent dashboard"
+  value = var.enable_observability && var.enable_agent_dashboards ? format(
+    "https://%s.console.aws.amazon.com/cloudwatch/home?region=%s#dashboards:name=%s",
+    local.dashboard_region_effective,
+    local.dashboard_region_effective,
+    urlencode(local.agent_dashboard_name_effective)
+  ) : null
+}

--- a/terraform/modules/agentcore-foundation/variables.tf
+++ b/terraform/modules/agentcore-foundation/variables.tf
@@ -136,6 +136,64 @@ variable "alarm_sns_topic_arn" {
   default     = ""
 }
 
+variable "enable_agent_dashboards" {
+  description = "Enable per-agent CloudWatch dashboard creation"
+  type        = bool
+  default     = false
+}
+
+variable "agent_dashboard_name" {
+  description = "Optional CloudWatch dashboard name override (defaults to <agent_name>-dashboard when empty)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = length(trimspace(var.agent_dashboard_name)) <= 255
+    error_message = "agent_dashboard_name must be 255 characters or fewer."
+  }
+}
+
+variable "dashboard_region" {
+  description = "Optional region override for dashboard widgets and console URL hint (defaults to region when empty)"
+  type        = string
+  default     = ""
+}
+
+variable "dashboard_widgets_override" {
+  description = "Optional JSON array string of CloudWatch dashboard widgets to replace the default widget set"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.dashboard_widgets_override == "" ? true : can(tolist(jsondecode(var.dashboard_widgets_override)))
+    error_message = "dashboard_widgets_override must be an empty string or a JSON array string of widget objects."
+  }
+}
+
+variable "dashboard_include_runtime_logs" {
+  description = "Include runtime log widgets in the default dashboard"
+  type        = bool
+  default     = false
+}
+
+variable "dashboard_include_code_interpreter_logs" {
+  description = "Include code interpreter log widgets in the default dashboard"
+  type        = bool
+  default     = false
+}
+
+variable "dashboard_include_browser_logs" {
+  description = "Include browser log widgets in the default dashboard"
+  type        = bool
+  default     = false
+}
+
+variable "dashboard_include_evaluator_logs" {
+  description = "Include evaluator log widgets in the default dashboard"
+  type        = bool
+  default     = false
+}
+
 variable "enable_waf" {
   description = "Enable WAF protection for API Gateway"
   type        = bool

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -49,6 +49,12 @@ output "agentcore_runtime_arn" {
   sensitive   = true
 }
 
+output "agentcore_inference_profile_arn" {
+  description = "Bedrock application inference profile ARN for per-agent cost isolation"
+  value       = module.agentcore_runtime.inference_profile_arn
+  sensitive   = true
+}
+
 output "agentcore_gateway_arn" {
   description = "AgentCore gateway ARN (useful for cross-account target policies)"
   value       = module.agentcore_foundation.gateway_arn
@@ -59,4 +65,14 @@ output "agentcore_gateway_role_arn" {
   description = "AgentCore gateway service role ARN (useful for cross-account Lambda resource policies)"
   value       = module.agentcore_foundation.gateway_role_arn
   sensitive   = true
+}
+
+output "agentcore_dashboard_name" {
+  description = "CloudWatch dashboard name for per-agent observability"
+  value       = module.agentcore_foundation.agent_dashboard_name
+}
+
+output "agentcore_dashboard_console_url" {
+  description = "CloudWatch console URL for the per-agent dashboard"
+  value       = module.agentcore_foundation.agent_dashboard_console_url
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -48,6 +48,21 @@ oauth_return_urls    = []
 enable_observability = true
 enable_xray          = true
 log_retention_days   = 30
+enable_agent_dashboards = false
+# agent_dashboard_name = "my-research-agent-dashboard"
+# dashboard_region = "us-east-1" # Defaults to region when empty
+# dashboard_widgets_override = jsonencode([
+#   {
+#     type   = "text"
+#     x      = 0
+#     y      = 0
+#     width  = 24
+#     height = 3
+#     properties = {
+#       markdown = "# Custom dashboard override"
+#     }
+#   }
+# ])
 
 # Foundation - Encryption
 enable_kms           = true
@@ -81,6 +96,13 @@ enable_inference_profile = false
 # inference_profile_description = "Application inference profile for agent runtime"
 # inference_profile_tags = {
 #   Project = "bedrock-agentcore"
+# }
+# Cost isolation pattern (Issue #10):
+# Use the application inference profile ARN as modelId for runtime/evaluator calls
+# to attribute Bedrock usage/costs per agent.
+# Example runtime_config snippet:
+# runtime_config = {
+#   modelId = "arn:aws:bedrock:<REGION>:<ACCOUNT_ID>:inference-profile/<PROFILE_ID>"
 # }
 
 # Runtime - Packaging

--- a/terraform/tests/validation/test_agent_dashboards_issue10.py
+++ b/terraform/tests/validation/test_agent_dashboards_issue10.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_foundation_module_defines_agent_dashboard_resource_and_inputs():
+    foundation_vars = _read("terraform/modules/agentcore-foundation/variables.tf")
+    observability_tf = _read("terraform/modules/agentcore-foundation/observability.tf")
+    foundation_outputs = _read("terraform/modules/agentcore-foundation/outputs.tf")
+
+    for token in [
+        'variable "enable_agent_dashboards"',
+        'variable "agent_dashboard_name"',
+        'variable "dashboard_region"',
+        'variable "dashboard_widgets_override"',
+    ]:
+        assert token in foundation_vars
+
+    assert 'resource "aws_cloudwatch_dashboard" "agent"' in observability_tf
+    assert "dashboard_include_runtime_logs" in observability_tf
+    assert "/aws/bedrock/agentcore/runtime/" in observability_tf
+    assert "/aws/bedrock/agentcore/gateway/" in observability_tf
+
+    assert 'output "agent_dashboard_name"' in foundation_outputs
+    assert 'output "agent_dashboard_console_url"' in foundation_outputs
+
+
+def test_root_wires_dashboard_settings_and_exposes_outputs():
+    root_main = _read("terraform/main.tf")
+    root_vars = _read("terraform/variables.tf")
+    root_outputs = _read("terraform/outputs.tf")
+
+    for token in [
+        'variable "enable_agent_dashboards"',
+        'variable "agent_dashboard_name"',
+        'variable "dashboard_region"',
+        'variable "dashboard_widgets_override"',
+    ]:
+        assert token in root_vars
+
+    assert "enable_agent_dashboards" in root_main
+    assert "dashboard_include_code_interpreter_logs" in root_main
+    assert "dashboard_include_evaluator_logs" in root_main
+
+    for token in [
+        'output "agentcore_dashboard_name"',
+        'output "agentcore_dashboard_console_url"',
+        'output "agentcore_inference_profile_arn"',
+    ]:
+        assert token in root_outputs
+
+
+def test_docs_cover_dashboard_usage_and_inference_profile_cost_isolation():
+    readme = _read("README.md")
+    tfvars_example = _read("terraform/terraform.tfvars.example")
+    docs_tf = _read("docs/terraform.md")
+
+    assert "Per-Agent Dashboards (Issue #10)" in readme
+    assert "use the created **application inference profile ARN as `modelId`**" in readme
+    assert "enable_agent_dashboards = false" in tfvars_example
+    assert "Use the application inference profile ARN as modelId" in tfvars_example
+
+    assert "input_enable_agent_dashboards" in docs_tf
+    assert "output_agentcore_dashboard_console_url" in docs_tf
+    assert "output_agentcore_inference_profile_arn" in docs_tf

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -150,6 +150,40 @@ variable "alarm_sns_topic_arn" {
   default     = ""
 }
 
+variable "enable_agent_dashboards" {
+  description = "Enable Terraform-managed per-agent CloudWatch dashboards"
+  type        = bool
+  default     = false
+}
+
+variable "agent_dashboard_name" {
+  description = "Optional CloudWatch dashboard name override (defaults to <agent_name>-dashboard when empty)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = length(trimspace(var.agent_dashboard_name)) <= 255
+    error_message = "agent_dashboard_name must be 255 characters or fewer."
+  }
+}
+
+variable "dashboard_region" {
+  description = "Optional dashboard widget/console region override (defaults to region when empty)"
+  type        = string
+  default     = ""
+}
+
+variable "dashboard_widgets_override" {
+  description = "Optional JSON array string of CloudWatch dashboard widgets to replace the default widget set"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.dashboard_widgets_override == "" ? true : can(tolist(jsondecode(var.dashboard_widgets_override)))
+    error_message = "dashboard_widgets_override must be an empty string or a JSON array string of widget objects."
+  }
+}
+
 # ===== SECURITY BATCH 3 VARIABLES =====
 
 variable "enable_waf" {
@@ -309,7 +343,7 @@ variable "inference_profile_name" {
   default     = ""
 
   validation {
-    condition     = var.enable_inference_profile ? length(trim(var.inference_profile_name)) > 0 : true
+    condition     = var.enable_inference_profile ? length(trimspace(var.inference_profile_name)) > 0 : true
     error_message = "inference_profile_name must be set when enable_inference_profile is true."
   }
 }


### PR DESCRIPTION
## Summary
- add optional Terraform-managed per-agent CloudWatch dashboard in `agentcore-foundation`
- wire dashboard inputs/outputs through the root module and expose dashboard console URL + inference profile ARN outputs
- document inference-profile cost isolation (`modelId = inference profile ARN`) and dashboard usage

## Validation
- `make preflight-session` ✅ (run at start and again before commit/push)
- `terraform -chdir=terraform fmt -check -recursive` ✅
- `terraform -chdir=terraform validate` ✅
- `terraform -chdir=terraform plan -backend=false -var-file=../examples/research-agent.tfvars` ⚠️ invalid flag in current Terraform (`-backend` is not a `plan` flag)
- `terraform -chdir=terraform plan -var-file=../examples/research-agent.tfvars` ⚠️ failed in this environment (no AWS credentials for `aws` / `aws.bff` providers)
- `tflint --chdir=terraform --recursive --config terraform/.tflint.hcl` ⚠️ local CLI rejects `--chdir` + `--recursive`; equivalent run succeeded: `tflint --recursive --config /mnt/c/Users/julia/worktrees/wt10/terraform/.tflint.hcl` from `terraform/`
- `checkov -d terraform --framework terraform --compact --config-file terraform/.checkov.yaml` ✅
- `pre-commit run --all-files` ⚠️ attempted twice; Terraform validate hook repeatedly fanned out `terraform init -backend=false` subprocesses and did not converge in a reasonable time in this environment

Closes #10