### PR TITLE
CI: implement segmented Terraform backend keys for GitLab executions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 # GitLab CI/CD Pipeline for Bedrock AgentCore Terraform
 # Uses Web Identity Federation (WIF) for AWS authentication
 # Requires: CI_ENVIRONMENT_ROLE_ARN_DEV/TEST/PROD, TF_STATE_BUCKET_DEV/TEST/PROD
+# Segmented backend keys additionally require per-environment app/agent IDs (defaults below).
 
 image:
   name: amazon/aws-cli:latest
@@ -29,9 +30,16 @@ variables:
   TF_VERSION: "1.14.3"
   TFLINT_VERSION: "0.50.3"
   AWS_DEFAULT_REGION: eu-west-2
+  TF_STATE_KEY_MODE: "segmented" # Escape hatch: set to legacy-env-only during phased migration
   DEV_EXAMPLE: "1-hello-world"
   TEST_EXAMPLE: "2-gateway-tool"
   PROD_EXAMPLE: "3-deepresearch"
+  DEV_TF_STATE_APP_ID: "acore-dev-v1"
+  DEV_TF_STATE_AGENT_NAME: "hello-world-s3-a1b2"
+  TEST_TF_STATE_APP_ID: "agentcore-test"
+  TEST_TF_STATE_AGENT_NAME: "titanic-data-analyzer-c3d4"
+  PROD_TF_STATE_APP_ID: "agentcore-prod"
+  PROD_TF_STATE_AGENT_NAME: "deep-research-agent-e5f6"
 
 # =============================================================================
 # Template: Install tools (cached binary, not re-downloaded each job)
@@ -121,13 +129,53 @@ variables:
   script:
     - |
       BACKEND_FILE="$TF_ROOT/backend-${CI_ENVIRONMENT_NAME}.tf"
+      TF_STATE_KEY_MODE="${TF_STATE_KEY_MODE:-segmented}"
+
+      slugify_backend_segment() {
+        RAW_VALUE="$1"
+        SEGMENT_LABEL="$2"
+        SANITIZED_VALUE="$(printf '%s' "$RAW_VALUE" \
+          | tr '[:upper:]' '[:lower:]' \
+          | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+        if [ -z "$SANITIZED_VALUE" ]; then
+          echo "ERROR: ${SEGMENT_LABEL} is empty after sanitization: ${RAW_VALUE}"
+          exit 1
+        fi
+        printf '%s' "$SANITIZED_VALUE"
+      }
+
+      case "$TF_STATE_KEY_MODE" in
+        legacy-env-only)
+          TF_STATE_KEY="agentcore/${CI_ENVIRONMENT_NAME}/terraform.tfstate"
+          echo "WARNING: Using legacy env-only backend key via TF_STATE_KEY_MODE=${TF_STATE_KEY_MODE}"
+          ;;
+        segmented)
+          if [ -z "${TF_STATE_APP_ID:-}" ]; then
+            echo "ERROR: TF_STATE_APP_ID is required for segmented backend keys"
+            exit 1
+          fi
+          if [ -z "${TF_STATE_AGENT_NAME:-}" ]; then
+            echo "ERROR: TF_STATE_AGENT_NAME is required for segmented backend keys"
+            exit 1
+          fi
+          TF_STATE_APP_ID_SEGMENT="$(slugify_backend_segment "$TF_STATE_APP_ID" "TF_STATE_APP_ID")"
+          TF_STATE_AGENT_NAME_SEGMENT="$(slugify_backend_segment "$TF_STATE_AGENT_NAME" "TF_STATE_AGENT_NAME")"
+          TF_STATE_KEY="agentcore/${CI_ENVIRONMENT_NAME}/${TF_STATE_APP_ID_SEGMENT}/${TF_STATE_AGENT_NAME_SEGMENT}/terraform.tfstate"
+          ;;
+        *)
+          echo "ERROR: Unsupported TF_STATE_KEY_MODE: ${TF_STATE_KEY_MODE} (expected segmented or legacy-env-only)"
+          exit 1
+          ;;
+      esac
+
+      echo "Terraform backend key: ${TF_STATE_KEY}"
       # Remove any other backend files to avoid conflicts
       find "$TF_ROOT" -maxdepth 1 -name 'backend-*.tf' -not -name "backend-${CI_ENVIRONMENT_NAME}.tf" -delete
       cat > "$BACKEND_FILE" <<EOF
       terraform {
         backend "s3" {
           bucket       = "${TF_STATE_BUCKET}"
-          key          = "agentcore/${CI_ENVIRONMENT_NAME}/terraform.tfstate"
+          key          = "${TF_STATE_KEY}"
           region       = "${AWS_DEFAULT_REGION}"
           encrypt      = true
           use_lockfile = true
@@ -384,6 +432,8 @@ plan:dev:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_DEV}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_DEV}
+    TF_STATE_APP_ID: ${DEV_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${DEV_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "dev"
     TF_VAR_app_id: "acore-dev-v1"
     TF_VAR_lambda_architecture: "arm64"
@@ -458,6 +508,8 @@ deploy:dev:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_DEV}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_DEV}
+    TF_STATE_APP_ID: ${DEV_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${DEV_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "dev"
     TF_VAR_app_id: "acore-dev-v1"
     TF_VAR_lambda_architecture: "arm64"
@@ -586,6 +638,8 @@ plan:test:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_TEST}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_TEST}
+    TF_STATE_APP_ID: ${TEST_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${TEST_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "test"
     TF_VAR_app_id: "agentcore-test"
     TF_VAR_lambda_architecture: "arm64"
@@ -625,6 +679,8 @@ deploy:test:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_TEST}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_TEST}
+    TF_STATE_APP_ID: ${TEST_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${TEST_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "test"
     TF_VAR_app_id: "agentcore-test"
     TF_VAR_lambda_architecture: "arm64"
@@ -775,6 +831,8 @@ plan:prod:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_PROD}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_PROD}
+    TF_STATE_APP_ID: ${PROD_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${PROD_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "prod"
     TF_VAR_app_id: "agentcore-prod"
     TF_VAR_lambda_architecture: "arm64"
@@ -811,6 +869,8 @@ deploy:prod:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_PROD}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_PROD}
+    TF_STATE_APP_ID: ${PROD_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${PROD_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "prod"
     TF_VAR_app_id: "agentcore-prod"
     TF_VAR_lambda_architecture: "arm64"
@@ -894,6 +954,8 @@ drift:dev:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_DEV}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_DEV}
+    TF_STATE_APP_ID: ${DEV_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${DEV_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "dev"
     DRIFT_EXAMPLE: ${DEV_EXAMPLE}
 
@@ -904,6 +966,8 @@ drift:test:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_TEST}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_TEST}
+    TF_STATE_APP_ID: ${TEST_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${TEST_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "test"
     DRIFT_EXAMPLE: ${TEST_EXAMPLE}
 
@@ -914,5 +978,7 @@ drift:prod:
   variables:
     AWS_ROLE_ARN: ${CI_ENVIRONMENT_ROLE_ARN_PROD}
     TF_STATE_BUCKET: ${TF_STATE_BUCKET_PROD}
+    TF_STATE_APP_ID: ${PROD_TF_STATE_APP_ID}
+    TF_STATE_AGENT_NAME: ${PROD_TF_STATE_AGENT_NAME}
     TF_VAR_environment: "prod"
     DRIFT_EXAMPLE: ${PROD_EXAMPLE}

--- a/docs/adr/0004-state-management.md
+++ b/docs/adr/0004-state-management.md
@@ -41,9 +41,11 @@ terraform {
 }
 ```
 
-> **Note**: CI generates the backend key as `agentcore/${CI_ENVIRONMENT_NAME}/terraform.tfstate`.
-> ADR 0013 documents a planned further segmentation (`agentcore/{env}/{app_id}/{agent_name}/terraform.tfstate`)
-> and the migration runbook is in `docs/runbooks/segmented-terraform-state-key-migration.md`.
+> **Note**: CI now defaults to the segmented backend key pattern
+> `agentcore/${CI_ENVIRONMENT_NAME}/${TF_STATE_APP_ID}/${TF_STATE_AGENT_NAME}/terraform.tfstate`.
+> ADR 0013 defines the strategy and the migration runbook is
+> `docs/runbooks/segmented-terraform-state-key-migration.md`. During phased migration,
+> some environments may temporarily use the legacy env-only key.
 
 ## State Structure
 

--- a/docs/runbooks/segmented-terraform-state-key-migration.md
+++ b/docs/runbooks/segmented-terraform-state-key-migration.md
@@ -238,7 +238,7 @@ Never manually edit the state JSON.
 
 ## CI/CD Notes
 
-- If GitLab CI or local scripts generate backend config files dynamically, update the generated `key` value to `agentcore/${ENV}/terraform.tfstate` before running `terraform init`.
+- If GitLab CI or local scripts generate backend config files dynamically, update the generated `key` value to `agentcore/${ENV}/${TF_STATE_APP_ID}/${TF_STATE_AGENT_NAME}/terraform.tfstate` before running `terraform init`.
 - Freeze overlapping deploy jobs during the migration window to avoid lock contention and split-brain state writes.
 
 ## Related References

--- a/docs/runbooks/state-recovery.md
+++ b/docs/runbooks/state-recovery.md
@@ -6,13 +6,17 @@ This runbook covers recovery procedures for Terraform state issues.
 
 ## Scenarios
 
-Set the state key variables for the environment you are recovering. The repo-standard backend key is segmented by environment (`agentcore/${ENV}/terraform.tfstate`).
+Set the state key variables for the environment you are recovering. The repo-standard CI backend key is segmented by environment + app + agent (`agentcore/${ENV}/${TF_STATE_APP_ID}/${TF_STATE_AGENT_NAME}/terraform.tfstate`).
 
 ```bash
 export ENV="<dev|test|prod>"
 export PROJECT_ID="<project-or-account-suffix>"
+export TF_STATE_APP_ID="<app-id-slug>"
+export TF_STATE_AGENT_NAME="<agent-name-slug>"
 export STATE_BUCKET="terraform-state-${ENV}-${PROJECT_ID}"
-export STATE_KEY="agentcore/${ENV}/terraform.tfstate"
+export STATE_KEY="agentcore/${ENV}/${TF_STATE_APP_ID}/${TF_STATE_AGENT_NAME}/terraform.tfstate"
+# Legacy (pre-ADR-0013 migration) fallback:
+# export STATE_KEY="agentcore/${ENV}/terraform.tfstate"
 ```
 
 ### 1. State File Corruption
@@ -56,7 +60,7 @@ terraform plan
 
 **Recovery Steps:**
 
-Terraform 1.10+ uses **Native S3 locking**. A lock file is created at `${STATE_KEY}.tflock` (for example `agentcore/dev/terraform.tfstate.tflock`).
+Terraform 1.10+ uses **Native S3 locking**. A lock file is created at `${STATE_KEY}.tflock` (for example `agentcore/dev/app/agent/terraform.tfstate.tflock`).
 
 ```bash
 # 1. Identify the lock ID from the error message


### PR DESCRIPTION
Closes #74

## Summary
- switch GitLab CI backend key rendering to segmented S3 state paths (`env/app_id/agent_name`)
- add CI input validation + slug sanitization + logged rendered key + legacy escape hatch (`TF_STATE_KEY_MODE=legacy-env-only`)
- update state recovery / migration docs and ADR 0004 note to reflect the new CI backend-key behavior

## Validation
- `make preflight-session` (start): PASS
- `make preflight-session` (before commit): PASS
- `pre-commit run --files .gitlab-ci.yml docs/runbooks/state-recovery.md docs/runbooks/segmented-terraform-state-key-migration.md docs/adr/0004-state-management.md`: PASS
- `.gitlab-ci.yml` YAML parse (custom loader tolerating GitLab `!reference` tags): PASS
- backend-key derivation smoke checks:
  - `agentcore/dev/acore-dev-v1/hello-world-s3-a1b2/terraform.tfstate`
  - `agentcore/test/ops-assistant/ops-assistant-core-f9e1/terraform.tfstate` (sanitized sample)
  - legacy escape hatch sample: `agentcore/dev/terraform.tfstate`

## Notes
- Default segmented state IDs are defined as top-level CI variables and mapped into plan/deploy/drift jobs for `dev`, `test`, and `prod`.
- `TF_STATE_KEY_MODE=legacy-env-only` provides a temporary migration escape hatch during phased backend-key migration.
