### PR TITLE
chore(checkov): classify BFF harness-default skips

### DIFF
--- a/terraform/modules/agentcore-bff/apigateway.tf
+++ b/terraform/modules/agentcore-bff/apigateway.tf
@@ -1,5 +1,6 @@
 resource "aws_api_gateway_rest_api" "bff" {
   # checkov:skip=CKV2_AWS_77: WAF on Rest API requires cost decision
+  # checkov:skip=CKV_AWS_237: Intentional harness default; zero-downtime REST API replacement requires parallel cutover design (#79)
   count = var.enable_bff ? 1 : 0
 
   name        = "agentcore-bff-${var.agent_name}"
@@ -42,6 +43,7 @@ resource "aws_api_gateway_deployment" "bff" {
 }
 
 resource "aws_api_gateway_stage" "bff" {
+  # checkov:skip=CKV_AWS_120: Intentional harness default; API caching is disabled for OIDC callbacks and per-session streaming responses
   # checkov:skip=CKV2_AWS_51: Client Cert not used (Token Handler pattern)
   # checkov:skip=CKV2_AWS_29: WAF managed at CloudFront layer (if enabled)
   # checkov:skip=CKV2_AWS_77: Log4j AMR managed by AWSManagedRulesCommonRuleSet in WAF ACL
@@ -79,6 +81,7 @@ resource "aws_wafv2_web_acl_association" "bff" {
 }
 
 resource "aws_api_gateway_method_settings" "bff" {
+  # checkov:skip=CKV_AWS_225: Intentional harness default; method caching is disabled to avoid caching auth/session and streaming traffic
   count = var.enable_bff ? 1 : 0
 
   rest_api_id = aws_api_gateway_rest_api.bff[0].id
@@ -146,6 +149,7 @@ resource "aws_api_gateway_authorizer" "token_handler" {
 # --- Methods: GET /auth/login ---
 
 resource "aws_api_gateway_method" "login" {
+  # checkov:skip=CKV_AWS_59: Intentional harness default; OIDC login entrypoint must be public and issues only a redirect
   # checkov:skip=CKV2_AWS_53: Validation skipped for redirect-only handler
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
@@ -167,6 +171,7 @@ resource "aws_api_gateway_integration" "login" {
 # --- Methods: GET /auth/callback ---
 
 resource "aws_api_gateway_method" "callback" {
+  # checkov:skip=CKV_AWS_59: Intentional harness default; OIDC callback must be public and validates state/session in Lambda
   # checkov:skip=CKV2_AWS_53: Validation skipped for OIDC callback
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id

--- a/terraform/modules/agentcore-bff/cloudfront.tf
+++ b/terraform/modules/agentcore-bff/cloudfront.tf
@@ -72,6 +72,8 @@ resource "aws_cloudfront_distribution" "bff" {
   # checkov:skip=CKV2_AWS_47: WAF association is optional; configure via cloudfront_waf_acl_arn for enterprise deployments
   # checkov:skip=CKV2_AWS_42: Custom SSL requires ACM cert (out of scope for harness default)
   # checkov:skip=CKV2_AWS_46: S3 Origin Access is enabled via OAC
+  # checkov:skip=CKV_AWS_310: Intentional harness default; origin failover needs multi-region BFF/API topology and cutover design (#79)
+  # checkov:skip=CKV_AWS_374: Intentional harness default; geo restrictions are workload policy choices and typically enforced in WAF
   count = var.enable_bff ? 1 : 0
 
   # Optional WAFv2 CLOUDFRONT-scope Web ACL association (must be in us-east-1)

--- a/terraform/modules/agentcore-bff/data.tf
+++ b/terraform/modules/agentcore-bff/data.tf
@@ -1,6 +1,7 @@
 # Session Store (DynamoDB)
 # Stores strict server-side sessions. Tokens NEVER touch the browser.
 resource "aws_dynamodb_table" "sessions" {
+  # checkov:skip=CKV_AWS_119: Intentional harness default; sessions use AWS-managed DynamoDB SSE (ADR-0008), CMK is optional enterprise hardening
   count = var.enable_bff ? 1 : 0
 
   name         = "agentcore-sessions-${var.agent_name}-${var.environment}"

--- a/terraform/tests/validation/test_bff_checkov_intentional_defaults.py
+++ b/terraform/tests/validation/test_bff_checkov_intentional_defaults.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_bff_checkov_intentional_default_skips_are_explicit_and_scoped():
+    apigw_tf = _read("terraform/modules/agentcore-bff/apigateway.tf")
+    cloudfront_tf = _read("terraform/modules/agentcore-bff/cloudfront.tf")
+    data_tf = _read("terraform/modules/agentcore-bff/data.tf")
+
+    assert "checkov:skip=CKV_AWS_237" in apigw_tf
+    assert "Intentional harness default" in apigw_tf
+    assert "checkov:skip=CKV_AWS_120" in apigw_tf
+    assert "checkov:skip=CKV_AWS_225" in apigw_tf
+    assert apigw_tf.count("checkov:skip=CKV_AWS_59") == 2
+
+    assert "checkov:skip=CKV_AWS_310" in cloudfront_tf
+    assert "checkov:skip=CKV_AWS_374" in cloudfront_tf
+    assert "Intentional harness default" in cloudfront_tf
+
+    assert "checkov:skip=CKV_AWS_119" in data_tf
+    assert "ADR-0008" in data_tf
+
+
+def test_bff_readme_documents_issue_78_classification_and_issue_79_hardening_handoff():
+    readme = _read("terraform/modules/agentcore-bff/README.md")
+
+    assert "## Checkov Classification (Issue #78)" in readme
+    assert "CKV_AWS_119" in readme
+    assert "CKV_AWS_120" in readme
+    assert "CKV_AWS_225" in readme
+    assert "CKV_AWS_237" in readme
+    assert "CKV_AWS_59" in readme
+    assert "CKV_AWS_310" in readme
+    assert "CKV_AWS_374" in readme
+    assert "#79" in readme
+    assert "CKV_AWS_86" in readme
+    assert "CKV_AWS_50" in readme
+    assert "CKV_AWS_272" in readme


### PR DESCRIPTION
Closes #78

## Summary
- add resource-level Checkov skips for BFF findings classified as intentional harness defaults (with explicit rationale)
- document the issue #78 classification and hand off remaining behavior-changing hardening findings to #79 in the BFF module README
- add a validation test to lock the skip classification and documentation handoff

## Checkov (BFF-only)
- before: 15 failures
- after: 7 failures
- remaining (hardening track #79): `CKV_AWS_86`, `CKV_AWS_50` (x3), `CKV_AWS_272` (x3)

## Validation
- `make preflight-session` (pass, run at start and pre-push)
- `pytest -q terraform/tests/validation/test_bff_checkov_intentional_defaults.py` (2 passed)
- `checkov -d terraform --framework terraform --compact --config-file terraform/.checkov.yaml` (expected failures remain; BFF subset reduced to #79 hardening items only)