### PR TITLE
ci: add BFF Checkov regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,26 @@ jobs:
       - name: Checkov scan
         run: checkov -d terraform --framework terraform --quiet --compact --config-file terraform/.checkov.yaml
 
+  checkov-bff-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkov-setup
+        with:
+          python_version: "3.12"
+      - name: Checkov JSON scan (BFF regression gate input)
+        run: |
+          set -euo pipefail
+          CHECKOV_JSON="${RUNNER_TEMP}/checkov-bff-regression.json"
+          # The full repo checkov scan may fail on known debt. This gate compares
+          # only BFF findings against the approved temporary baseline for #79.
+          set +e
+          checkov -d terraform --framework terraform --quiet --compact --config-file terraform/.checkov.yaml --output json > "${CHECKOV_JSON}"
+          CHECKOV_EXIT=$?
+          set -e
+          echo "Full Checkov exit code (informational for BFF regression gate): ${CHECKOV_EXIT}"
+          python3 terraform/scripts/ci/checkov_bff_regression_gate.py --input "${CHECKOV_JSON}"
+
   examples-validate:
     runs-on: ubuntu-latest
     steps:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -491,6 +491,9 @@ pre-commit run --all-files
 - Uses `terraform init -backend=false` on the runner (local only, no AWS).
 - Uses shared GitHub Actions for Terraform, TFLint, and Checkov setup plus caching.
 - Caches Terraform plugins, TFLint plugins, and pip downloads to speed CI runs.
+- Includes `checkov-bff-regression`, a BFF-only Checkov baseline gate that compares BFF findings to the temporary approved `#79` hardening subset and fails on regressions or baseline drift.
+- The full `checkov` job remains for repo-wide visibility; `checkov-bff-regression` is the scoped gate for BFF Checkov regression control.
+- When `#79` reduces/removes the remaining BFF findings, update `terraform/scripts/ci/checkov_bff_regression_gate.py` baseline pairs in the same PR with validation evidence.
 - No deployments run in GitHub Actions.
 
 ### GitLab CI (deployment pipeline)

--- a/terraform/scripts/ci/checkov_bff_regression_gate.py
+++ b/terraform/scripts/ci/checkov_bff_regression_gate.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail CI only on unexpected BFF Checkov regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+BFF_RESOURCE_PREFIX = "module.agentcore_bff."
+
+# Temporary approved baseline for the behavior-changing hardening work tracked in #79.
+EXPECTED_BFF_FAILURE_PAIRS: tuple[tuple[str, str], ...] = (
+    ("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
+    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
+    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
+    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
+    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    check_id: str
+    resource: str
+    file_path: str
+
+    @property
+    def pair(self) -> tuple[str, str]:
+        return (self.check_id, self.resource)
+
+
+@dataclass(frozen=True)
+class GateResult:
+    bff_findings: tuple[Finding, ...]
+    unexpected: tuple[tuple[str, str], ...]
+    missing_expected: tuple[tuple[str, str], ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.unexpected and not self.missing_expected
+
+
+def _failed_checks(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    results = payload.get("results")
+    if not isinstance(results, dict):
+        raise ValueError("Checkov JSON missing 'results' object")
+    failed_checks = results.get("failed_checks")
+    if failed_checks is None:
+        return []
+    if not isinstance(failed_checks, list):
+        raise ValueError("Checkov JSON field 'results.failed_checks' is not a list")
+    return [entry for entry in failed_checks if isinstance(entry, dict)]
+
+
+def extract_bff_findings(payload: dict[str, Any]) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for item in _failed_checks(payload):
+        resource = str(item.get("resource", "") or "")
+        if not resource.startswith(BFF_RESOURCE_PREFIX):
+            continue
+        findings.append(
+            Finding(
+                check_id=str(item.get("check_id", "") or ""),
+                resource=resource,
+                file_path=str(item.get("file_path", "") or item.get("file_abs_path", "") or ""),
+            )
+        )
+    return tuple(sorted(findings, key=lambda f: (f.check_id, f.resource, f.file_path)))
+
+
+def evaluate_bff_regression(findings: tuple[Finding, ...]) -> GateResult:
+    actual_counter = Counter(f.pair for f in findings)
+    expected_counter = Counter(EXPECTED_BFF_FAILURE_PAIRS)
+
+    unexpected = tuple(sorted((actual_counter - expected_counter).elements()))
+    missing_expected = tuple(sorted((expected_counter - actual_counter).elements()))
+
+    return GateResult(
+        bff_findings=findings,
+        unexpected=unexpected,
+        missing_expected=missing_expected,
+    )
+
+
+def format_result(result: GateResult) -> str:
+    lines: list[str] = [
+        "BFF Checkov Regression Gate",
+        f"Observed BFF failed findings: {len(result.bff_findings)}",
+        f"Expected BFF failed findings baseline (#79): {len(EXPECTED_BFF_FAILURE_PAIRS)}",
+    ]
+
+    if result.bff_findings:
+        lines.append("")
+        lines.append("Observed BFF failures:")
+        for finding in result.bff_findings:
+            lines.append(f"  - {finding.check_id} | {finding.resource} ({finding.file_path})")
+
+    if result.unexpected:
+        lines.append("")
+        lines.append("Unexpected BFF failures (regression):")
+        for check_id, resource in result.unexpected:
+            lines.append(f"  - {check_id} | {resource}")
+
+    if result.missing_expected:
+        lines.append("")
+        lines.append("Expected baseline failures missing (baseline drift):")
+        lines.append("  Update the baseline in this script when #79 intentionally changes the remaining BFF hardening set.")
+        for check_id, resource in result.missing_expected:
+            lines.append(f"  - {check_id} | {resource}")
+
+    lines.append("")
+    lines.append(
+        "PASS: BFF Checkov failures match the approved #79 hardening baseline."
+        if result.ok
+        else "FAIL: BFF Checkov failures differ from the approved #79 hardening baseline."
+    )
+    return "\n".join(lines)
+
+
+def load_checkov_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Input file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Path to Checkov JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        payload = load_checkov_json(Path(args.input))
+        result = evaluate_bff_regression(extract_bff_findings(payload))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_result(result))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/tests/validation/test_checkov_bff_regression_gate.py
+++ b/terraform/tests/validation/test_checkov_bff_regression_gate.py
@@ -1,0 +1,90 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "terraform/scripts/ci/checkov_bff_regression_gate.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("checkov_bff_regression_gate", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _payload(failed_checks):
+    return {"results": {"failed_checks": failed_checks}}
+
+
+def _finding(check_id: str, resource: str, file_path: str = "/modules/agentcore-bff/test.tf"):
+    return {"check_id": check_id, "resource": resource, "file_path": file_path}
+
+
+def test_gate_passes_when_bff_findings_match_expected_baseline():
+    gate = _load_module()
+    payload = _payload(
+        [
+            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
+            _finding("CKV_AWS_999", "module.agentcore_foundation.aws_s3_bucket.example"),
+        ]
+    )
+
+    result = gate.evaluate_bff_regression(gate.extract_bff_findings(payload))
+
+    assert result.ok is True
+    assert result.unexpected == ()
+    assert result.missing_expected == ()
+
+
+def test_gate_fails_on_unexpected_bff_finding_and_reports_it():
+    gate = _load_module()
+    payload = _payload(
+        [
+            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
+            _finding("CKV_AWS_123", "module.agentcore_bff.aws_api_gateway_stage.bff"),
+        ]
+    )
+
+    result = gate.evaluate_bff_regression(gate.extract_bff_findings(payload))
+    summary = gate.format_result(result)
+
+    assert result.ok is False
+    assert ("CKV_AWS_123", "module.agentcore_bff.aws_api_gateway_stage.bff") in result.unexpected
+    assert "Unexpected BFF failures (regression):" in summary
+
+
+def test_gate_fails_when_expected_baseline_drifts():
+    gate = _load_module()
+    payload = _payload(
+        [
+            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
+            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
+            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
+        ]
+    )
+
+    result = gate.evaluate_bff_regression(gate.extract_bff_findings(payload))
+    summary = gate.format_result(result)
+
+    assert result.ok is False
+    assert ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy") in result.missing_expected
+    assert "Expected baseline failures missing (baseline drift):" in summary


### PR DESCRIPTION
Closes #83

## Summary
- add a new GitHub Actions job `checkov-bff-regression` that runs Checkov JSON and evaluates only BFF findings against the approved temporary baseline for #79
- keep the existing full `checkov` job unchanged for repo-wide visibility
- add a Python gate script and unit tests for BFF failure-set classification
- document the new CI gate and baseline maintenance workflow in `DEVELOPER_GUIDE.md`

## Validation
- `make preflight-session` (PASS, run in `wt83` at start and before commit/push)
- `pytest -q terraform/tests/validation/test_checkov_bff_regression_gate.py` (PASS, 3 passed)
- `checkov -d terraform --framework terraform --compact --config-file terraform/.checkov.yaml --output json > .scratch/checkov_bff_gate.json` (expected non-zero due repo debt)
- `python3 terraform/scripts/ci/checkov_bff_regression_gate.py --input .scratch/checkov_bff_gate.json` (PASS; observed BFF failed findings: 7 / expected baseline: 7)

## Notes
- The BFF baseline in the gate script is intentionally temporary and must be reduced/removed as `#79` lands hardening changes.