### PR TITLE
fix(bff): resolve Checkov findings for #79

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           mkdir .generated-test
           copier copy --force --trust \
-            --data agent_name=ci-agent \
+            --data agent_name=ci-agent-core-a1b2 \
             --data app_id=ci-agent \
             --data region=us-east-1 \
             --data environment=dev \

--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -151,13 +151,13 @@ These skips preserve current harness behavior and document where enterprise cont
 - `CKV_AWS_310` (CloudFront origin failover): Active/passive failover requires additional multi-region topology and cutover logic beyond the default harness.
 - `CKV_AWS_374` (CloudFront geo restriction): Geographic restrictions are tenant/workload policy decisions and should generally be enforced with WAF geo-match rules.
 
-### Remaining BFF Hardening Findings (Track in #79)
+### BFF Hardening Completion (Issue #79)
 
-The following findings remain intentionally unskipped in issue `#78` because addressing them changes runtime behavior or adds infrastructure:
+Issue `#79` completes the remaining BFF Checkov hardening set from `#78`:
 
-- `CKV_AWS_86` (CloudFront access logging)
-- `CKV_AWS_50` (Lambda X-Ray tracing)
-- `CKV_AWS_272` (Lambda code signing)
+- `CKV_AWS_86` (CloudFront access logging): remediated by enabling `logging_config` on the distribution (reusing the shared logging bucket when configured, otherwise the SPA bucket).
+- `CKV_AWS_50` (Lambda X-Ray tracing): remediated by enabling `tracing_config { mode = "Active" }` on the auth handler, authorizer, and proxy Lambdas.
+- `CKV_AWS_272` (Lambda code signing): documented as a resource-level skip because signer profile/trust setup is an external dependency and not a harness default.
 
 ## Known Failure Modes (Rule 16)
 

--- a/terraform/modules/agentcore-bff/cloudfront.tf
+++ b/terraform/modules/agentcore-bff/cloudfront.tf
@@ -104,6 +104,12 @@ resource "aws_cloudfront_distribution" "bff" {
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 
+  logging_config {
+    bucket          = local.cloudfront_access_logs_bucket_domain
+    include_cookies = false
+    prefix          = "${local.cloudfront_access_logs_prefix}${var.agent_name}/${var.environment}/"
+  }
+
   # Default Behavior: S3 (Frontend)
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]

--- a/terraform/modules/agentcore-bff/lambda.tf
+++ b/terraform/modules/agentcore-bff/lambda.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "auth_handler" {
   # checkov:skip=CKV_AWS_116: DLQ not required for synchronous OIDC handler
   # checkov:skip=CKV_AWS_117: Public access required for OIDC issuer reachability
   # checkov:skip=CKV_AWS_115: Concurrency managed at account/module level
+  # checkov:skip=CKV_AWS_272: Lambda code signing requires signer profile/trust setup and is optional for harness defaults (#79)
 
   count = var.enable_bff ? 1 : 0
 
@@ -40,6 +41,10 @@ resource "aws_lambda_function" "auth_handler" {
   filename                       = data.archive_file.auth_handler[0].output_path
   source_code_hash               = data.archive_file.auth_handler[0].output_base64sha256
   reserved_concurrent_executions = var.reserved_concurrency > 0 ? var.reserved_concurrency : null
+
+  tracing_config {
+    mode = "Active"
+  }
 
   environment {
     variables = {
@@ -62,6 +67,7 @@ resource "aws_lambda_function" "authorizer" {
   # checkov:skip=CKV_AWS_116: DLQ not required for authorizer
   # checkov:skip=CKV_AWS_117: Internal VPC access not required
   # checkov:skip=CKV_AWS_115: Concurrency managed at account/module level
+  # checkov:skip=CKV_AWS_272: Lambda code signing requires signer profile/trust setup and is optional for harness defaults (#79)
 
   count = var.enable_bff ? 1 : 0
 
@@ -74,6 +80,10 @@ resource "aws_lambda_function" "authorizer" {
   filename                       = data.archive_file.authorizer[0].output_path
   source_code_hash               = data.archive_file.authorizer[0].output_base64sha256
   reserved_concurrent_executions = var.reserved_concurrency > 0 ? var.reserved_concurrency : null
+
+  tracing_config {
+    mode = "Active"
+  }
 
   environment {
     variables = {
@@ -92,6 +102,7 @@ resource "aws_lambda_function" "proxy" {
   # checkov:skip=CKV2_AWS_75: Protected by Authorizer
   # checkov:skip=CKV_AWS_116: DLQ not required for streaming proxy
   # checkov:skip=CKV_AWS_117: Public access required for Bedrock API reachability
+  # checkov:skip=CKV_AWS_272: Lambda code signing requires signer profile/trust setup and is optional for harness defaults (#79)
 
   count = var.enable_bff ? 1 : 0
 
@@ -104,6 +115,10 @@ resource "aws_lambda_function" "proxy" {
   filename                       = data.archive_file.proxy[0].output_path
   source_code_hash               = data.archive_file.proxy[0].output_base64sha256
   reserved_concurrent_executions = var.reserved_concurrency > 0 ? var.reserved_concurrency : null
+
+  tracing_config {
+    mode = "Active"
+  }
 
   environment {
     variables = {

--- a/terraform/modules/agentcore-bff/locals.tf
+++ b/terraform/modules/agentcore-bff/locals.tf
@@ -3,6 +3,9 @@ locals {
 
   audit_logs_enabled = var.enable_bff && var.enable_audit_log_persistence && trimspace(var.logging_bucket_id) != ""
   audit_logs_prefix  = "audit/bff-proxy"
+  # CloudFront access logs require an S3 bucket DNS name. Reuse the shared logging bucket when configured.
+  cloudfront_access_logs_bucket_domain = trimspace(var.logging_bucket_id) != "" ? "${var.logging_bucket_id}.s3.amazonaws.com" : aws_s3_bucket.spa[0].bucket_domain_name
+  cloudfront_access_logs_prefix        = "cloudfront-access-logs/"
 
   audit_logs_events_prefix         = "${local.audit_logs_prefix}/events/"
   audit_logs_athena_results_prefix = "${local.audit_logs_prefix}/athena-results/"

--- a/terraform/scripts/ci/checkov_bff_regression_gate.py
+++ b/terraform/scripts/ci/checkov_bff_regression_gate.py
@@ -14,16 +14,8 @@ from typing import Any
 
 BFF_RESOURCE_PREFIX = "module.agentcore_bff."
 
-# Temporary approved baseline for the behavior-changing hardening work tracked in #79.
-EXPECTED_BFF_FAILURE_PAIRS: tuple[tuple[str, str], ...] = (
-    ("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
-    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
-    ("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
-    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
-    ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
-)
+# Approved baseline after #79 hardening completion: no remaining BFF Checkov failures.
+EXPECTED_BFF_FAILURE_PAIRS: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -112,7 +104,7 @@ def format_result(result: GateResult) -> str:
     if result.missing_expected:
         lines.append("")
         lines.append("Expected baseline failures missing (baseline drift):")
-        lines.append("  Update the baseline in this script when #79 intentionally changes the remaining BFF hardening set.")
+        lines.append("  Update the baseline in this script when #79+ changes the approved BFF hardening state.")
         for check_id, resource in result.missing_expected:
             lines.append(f"  - {check_id} | {resource}")
 

--- a/terraform/tests/validation/test_checkov_bff_regression_gate.py
+++ b/terraform/tests/validation/test_checkov_bff_regression_gate.py
@@ -26,18 +26,7 @@ def _finding(check_id: str, resource: str, file_path: str = "/modules/agentcore-
 
 def test_gate_passes_when_bff_findings_match_expected_baseline():
     gate = _load_module()
-    payload = _payload(
-        [
-            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
-            _finding("CKV_AWS_999", "module.agentcore_foundation.aws_s3_bucket.example"),
-        ]
-    )
+    payload = _payload([_finding("CKV_AWS_999", "module.agentcore_foundation.aws_s3_bucket.example")])
 
     result = gate.evaluate_bff_regression(gate.extract_bff_findings(payload))
 
@@ -50,13 +39,6 @@ def test_gate_fails_on_unexpected_bff_finding_and_reports_it():
     gate = _load_module()
     payload = _payload(
         [
-            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy"),
             _finding("CKV_AWS_123", "module.agentcore_bff.aws_api_gateway_stage.bff"),
         ]
     )
@@ -71,20 +53,12 @@ def test_gate_fails_on_unexpected_bff_finding_and_reports_it():
 
 def test_gate_fails_when_expected_baseline_drifts():
     gate = _load_module()
-    payload = _payload(
-        [
-            _finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.authorizer"),
-            _finding("CKV_AWS_50", "module.agentcore_bff.aws_lambda_function.proxy"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.auth_handler"),
-            _finding("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.authorizer"),
-        ]
-    )
+    payload = _payload([_finding("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff")])
 
     result = gate.evaluate_bff_regression(gate.extract_bff_findings(payload))
     summary = gate.format_result(result)
 
     assert result.ok is False
-    assert ("CKV_AWS_272", "module.agentcore_bff.aws_lambda_function.proxy") in result.missing_expected
-    assert "Expected baseline failures missing (baseline drift):" in summary
+    assert ("CKV_AWS_86", "module.agentcore_bff.aws_cloudfront_distribution.bff") in result.unexpected
+    assert result.missing_expected == ()
+    assert "Unexpected BFF failures (regression):" in summary


### PR DESCRIPTION
Closes #79

Completes BFF Checkov hardening for the remaining findings, updates the BFF regression baseline gate to the post-#79 zero-failure state, and refreshes the CI template test input to a valid agent_name example.