### PR TITLE
feat(bff): add optional CloudFront access logging controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ Operational verification points:
 | `bff_agentcore_runtime_arn` | `string` | `""` | AgentCore runtime ARN for the proxy (required if `enable_bff=true` and `enable_runtime=false`). |
 | `bff_agentcore_runtime_role_arn` | `string` | `""` | Optional runtime IAM role ARN for BFF to assume (set for cross-account runtime identity propagation). |
 | `proxy_reserved_concurrency` | `number` | `10` | Reserved concurrent executions for the BFF proxy Lambda. |
+| `enable_bff_cloudfront_access_logging` | `bool` | `true` | Enable CloudFront standard access logging for the BFF distribution (default preserves current harness behavior). |
+| `bff_cloudfront_access_logs_prefix` | `string` | `"cloudfront-access-logs/"` | S3 key prefix for BFF CloudFront standard access logs (no leading slash). |
 
 ---
 

--- a/examples/5-integrated/main.tf
+++ b/examples/5-integrated/main.tf
@@ -141,6 +141,9 @@ module "agentcore" {
   oidc_issuer            = "https://example.com"
   oidc_client_id         = "test-client"
   oidc_client_secret_arn = "arn:aws:secretsmanager:${var.region}:123456789012:secret:test-secret"
+  # Optional CloudFront standard access logging controls (Issue #64)
+  # enable_bff_cloudfront_access_logging = false
+  # bff_cloudfront_access_logs_prefix    = "cloudfront-access-logs/examples/5-integrated/"
 
   tags = {
     Example = "5-integrated"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -174,15 +174,17 @@ locals {
 module "agentcore_bff" {
   source = "./modules/agentcore-bff"
 
-  enable_bff                   = var.enable_bff
-  agent_name                   = var.agent_name
-  app_id                       = local.app_id
-  region                       = local.bff_region
-  agentcore_region             = local.agentcore_region
-  environment                  = var.environment
-  tags                         = local.canonical_tags
-  log_retention_days           = var.log_retention_days
-  enable_audit_log_persistence = var.enable_bff_audit_log_persistence
+  enable_bff                       = var.enable_bff
+  agent_name                       = var.agent_name
+  app_id                           = local.app_id
+  region                           = local.bff_region
+  agentcore_region                 = local.agentcore_region
+  environment                      = var.environment
+  tags                             = local.canonical_tags
+  log_retention_days               = var.log_retention_days
+  enable_audit_log_persistence     = var.enable_bff_audit_log_persistence
+  enable_cloudfront_access_logging = var.enable_bff_cloudfront_access_logging
+  cloudfront_access_logs_prefix    = var.bff_cloudfront_access_logs_prefix
 
   # Auth Configuration
 

--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -33,6 +33,10 @@ module "agentcore_bff" {
   # Optional compliance feature (Issue #30)
   logging_bucket_id             = module.agentcore_foundation.access_logs_bucket_id
   enable_audit_log_persistence  = true
+
+  # Optional CloudFront access logging controls (Issue #64)
+  # enable_cloudfront_access_logging = false
+  # cloudfront_access_logs_prefix    = "cloudfront-access-logs/bff/"
 }
 ```
 
@@ -74,6 +78,58 @@ Useful outputs:
 - `audit_logs_athena_database`
 - `audit_logs_athena_table`
 - `audit_logs_athena_workgroup`
+
+## Optional CloudFront Access Logging (Issue #64)
+
+The BFF CloudFront distribution supports **standard access logging** with explicit Terraform controls:
+
+- `enable_cloudfront_access_logging` (default `true` to preserve current harness behavior)
+- `cloudfront_access_logs_prefix` (default `cloudfront-access-logs/`)
+
+When enabled, the module writes CloudFront standard logs to:
+
+- the shared `logging_bucket_id` bucket (if provided), or
+- the SPA bucket (fallback)
+
+### Usage
+
+```hcl
+module "agentcore_bff" {
+  source = "./modules/agentcore-bff"
+
+  enable_bff = true
+  # ... other required variables ...
+
+  # Explicitly disable CloudFront standard access logs
+  enable_cloudfront_access_logging = false
+}
+```
+
+```hcl
+module "agentcore_bff" {
+  source = "./modules/agentcore-bff"
+
+  enable_bff = true
+  # ... other required variables ...
+
+  # Keep logging enabled (default) and customize the S3 prefix
+  cloudfront_access_logs_prefix = "cloudfront-access-logs/edge/"
+}
+```
+
+### Operational Considerations
+
+| Topic | Guidance |
+|---|---|
+| **Delivery semantics** | CloudFront standard logs are best-effort and can arrive late; use them for troubleshooting/analysis rather than exact billing reconciliation. |
+| **Destination bucket requirements** | CloudFront standard logging (legacy S3 delivery used by `logging_config`) requires an S3 destination that supports ACLs; buckets with S3 Object Ownership set to **Bucket owner enforced** cannot receive these logs. |
+| **Bucket separation** | AWS recommends a separate S3 bucket (or at least a separate prefix) for CloudFront logs, especially if you also use CloudFront standard logging v2 or other log producers. |
+| **Retention / cost** | CloudFront does not charge to enable standard logs, but S3 storage/requests and downstream analytics (Athena/Glue/Firehose) incur cost. Apply lifecycle retention to the destination bucket/prefix. |
+| **Analytics integration** | You can analyze CloudFront standard logs with Athena and co-locate them under a distinct prefix alongside BFF audit logs/WAF logs for shared observability workflows. |
+
+References:
+- AWS CloudFront Access Logs: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
+- AWS CloudFront Standard Logging (legacy, S3): https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html
 
 ## Optional CloudFront WAF Association (Issue #54)
 
@@ -155,7 +211,7 @@ These skips preserve current harness behavior and document where enterprise cont
 
 Issue `#79` completes the remaining BFF Checkov hardening set from `#78`:
 
-- `CKV_AWS_86` (CloudFront access logging): remediated by enabling `logging_config` on the distribution (reusing the shared logging bucket when configured, otherwise the SPA bucket).
+- `CKV_AWS_86` (CloudFront access logging): remediated by default-enabled `logging_config` on the distribution, with an explicit opt-out toggle for deployments that must disable or defer CloudFront standard logging.
 - `CKV_AWS_50` (Lambda X-Ray tracing): remediated by enabling `tracing_config { mode = "Active" }` on the auth handler, authorizer, and proxy Lambdas.
 - `CKV_AWS_272` (Lambda code signing): documented as a resource-level skip because signer profile/trust setup is an external dependency and not a harness default.
 

--- a/terraform/modules/agentcore-bff/cloudfront.tf
+++ b/terraform/modules/agentcore-bff/cloudfront.tf
@@ -104,10 +104,13 @@ resource "aws_cloudfront_distribution" "bff" {
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 
-  logging_config {
-    bucket          = local.cloudfront_access_logs_bucket_domain
-    include_cookies = false
-    prefix          = "${local.cloudfront_access_logs_prefix}${var.agent_name}/${var.environment}/"
+  dynamic "logging_config" {
+    for_each = local.cloudfront_access_logging_enabled ? [1] : []
+    content {
+      bucket          = local.cloudfront_access_logs_bucket_domain
+      include_cookies = false
+      prefix          = "${local.cloudfront_access_logs_prefix}${var.agent_name}/${var.environment}/"
+    }
   }
 
   # Default Behavior: S3 (Frontend)

--- a/terraform/modules/agentcore-bff/locals.tf
+++ b/terraform/modules/agentcore-bff/locals.tf
@@ -1,11 +1,12 @@
 locals {
   agentcore_region = var.agentcore_region != "" ? var.agentcore_region : var.region
 
-  audit_logs_enabled = var.enable_bff && var.enable_audit_log_persistence && trimspace(var.logging_bucket_id) != ""
-  audit_logs_prefix  = "audit/bff-proxy"
+  audit_logs_enabled                = var.enable_bff && var.enable_audit_log_persistence && trimspace(var.logging_bucket_id) != ""
+  cloudfront_access_logging_enabled = var.enable_bff && var.enable_cloudfront_access_logging
+  audit_logs_prefix                 = "audit/bff-proxy"
   # CloudFront access logs require an S3 bucket DNS name. Reuse the shared logging bucket when configured.
   cloudfront_access_logs_bucket_domain = trimspace(var.logging_bucket_id) != "" ? "${var.logging_bucket_id}.s3.amazonaws.com" : aws_s3_bucket.spa[0].bucket_domain_name
-  cloudfront_access_logs_prefix        = "cloudfront-access-logs/"
+  cloudfront_access_logs_prefix        = "${trimsuffix(trimspace(var.cloudfront_access_logs_prefix), "/")}/"
 
   audit_logs_events_prefix         = "${local.audit_logs_prefix}/events/"
   audit_logs_athena_results_prefix = "${local.audit_logs_prefix}/athena-results/"

--- a/terraform/modules/agentcore-bff/variables.tf
+++ b/terraform/modules/agentcore-bff/variables.tf
@@ -56,6 +56,26 @@ variable "logging_bucket_id" {
   default     = ""
 }
 
+variable "enable_cloudfront_access_logging" {
+  description = "Enable CloudFront standard access logging for the BFF distribution"
+  type        = bool
+  default     = true
+}
+
+variable "cloudfront_access_logs_prefix" {
+  description = "S3 key prefix for CloudFront standard access logs (no leading slash)"
+  type        = string
+  default     = "cloudfront-access-logs/"
+
+  validation {
+    condition = (
+      trimspace(var.cloudfront_access_logs_prefix) != "" &&
+      !startswith(trimspace(var.cloudfront_access_logs_prefix), "/")
+    )
+    error_message = "cloudfront_access_logs_prefix must be non-empty and must not start with '/'."
+  }
+}
+
 variable "enable_audit_log_persistence" {
   description = "Persist BFF proxy audit shadow JSON to S3 and provision Athena/Glue metadata"
   type        = bool

--- a/terraform/variables_bff.tf
+++ b/terraform/variables_bff.tf
@@ -12,6 +12,26 @@ variable "enable_bff_audit_log_persistence" {
   default     = false
 }
 
+variable "enable_bff_cloudfront_access_logging" {
+  description = "Enable CloudFront standard access logging for the BFF distribution"
+  type        = bool
+  default     = true
+}
+
+variable "bff_cloudfront_access_logs_prefix" {
+  description = "S3 key prefix for BFF CloudFront standard access logs (no leading slash)"
+  type        = string
+  default     = "cloudfront-access-logs/"
+
+  validation {
+    condition = (
+      trimspace(var.bff_cloudfront_access_logs_prefix) != "" &&
+      !startswith(trimspace(var.bff_cloudfront_access_logs_prefix), "/")
+    )
+    error_message = "bff_cloudfront_access_logs_prefix must be non-empty and must not start with '/'."
+  }
+}
+
 variable "oidc_issuer" {
   description = "OIDC Issuer URL"
   type        = string


### PR DESCRIPTION
## Summary
- add optional BFF CloudFront standard access logging controls (default-enabled toggle + validated prefix)
- make CloudFront `logging_config` conditional while preserving current harness default behavior
- document usage/ops considerations and add validation coverage for the new wiring

## Validation
- `pytest -q terraform/tests/validation/test_bff_checkov_intentional_defaults.py terraform/modules/agentcore-bff/tests/test_waf_config.py` ✅
- `pytest -q terraform/tests/validation/test_bff_checkov_intentional_defaults.py` ✅ (post-`terraform fmt` rerun)
- `checkov -d terraform/modules/agentcore-bff --framework terraform --compact --check CKV_AWS_86` ✅
- `terraform -chdir=terraform fmt -check -recursive` ✅
- `terraform fmt -check examples/5-integrated/main.tf` ✅
- `make preflight-session` ✅ (start + pre-commit stage)

## Notes
- `terraform -chdir=terraform validate` and `pre-commit run --all-files` were attempted but blocked in this environment by hanging provider downloads during repeated `terraform init -backend=false` subprocesses.

Closes #64
