### PR TITLE
Fix BFF CKV2_AWS_53 regression gate failures for tenant admin methods

### DIFF
--- a/terraform/modules/agentcore-bff/README.md
+++ b/terraform/modules/agentcore-bff/README.md
@@ -223,6 +223,7 @@ These skips preserve current harness behavior and document where enterprise cont
 - `CKV_AWS_120` / `CKV_AWS_225` (API Gateway caching): Caching is intentionally disabled because the BFF mixes OIDC auth endpoints and per-session streaming `/api/chat` traffic.
 - `CKV_AWS_237` (API Gateway create-before-destroy): Zero-downtime REST API replacement requires a parallel cutover pattern and is not the harness default.
 - `CKV_AWS_59` on `/auth/login` and `/auth/callback`: These OIDC entrypoints must be public by design; state/session checks occur in the token-handler Lambda flow.
+- `CKV2_AWS_53` on six tenant-admin API methods (Issue `#91`): These `HTTP_PROXY` routes validate tenant-admin request semantics in the BFF proxy Lambda, where Rule 14.1 tenant/session ownership checks and authorizer context are available. Skips are scoped to the six tenant-admin `aws_api_gateway_method` resources only.
 - `CKV_AWS_310` (CloudFront origin failover): Active/passive failover requires additional multi-region topology and cutover logic beyond the default harness.
 - `CKV_AWS_374` (CloudFront geo restriction): Geographic restrictions are tenant/workload policy decisions and should generally be enforced with WAF geo-match rules.
 

--- a/terraform/modules/agentcore-bff/apigateway.tf
+++ b/terraform/modules/agentcore-bff/apigateway.tf
@@ -310,6 +310,7 @@ resource "aws_api_gateway_integration" "chat" {
 
 # POST /api/tenancy/v1/admin/tenants
 resource "aws_api_gateway_method" "create_tenant" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenants[0].id
@@ -332,6 +333,7 @@ resource "aws_api_gateway_integration" "create_tenant" {
 
 # POST /api/tenancy/v1/admin/tenants/{tenantId}:suspend
 resource "aws_api_gateway_method" "suspend_tenant" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenant_suspend[0].id
@@ -354,6 +356,7 @@ resource "aws_api_gateway_integration" "suspend_tenant" {
 
 # POST /api/tenancy/v1/admin/tenants/{tenantId}:rotate-credentials
 resource "aws_api_gateway_method" "rotate_tenant_credentials" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenant_rotate_credentials[0].id
@@ -376,6 +379,7 @@ resource "aws_api_gateway_integration" "rotate_tenant_credentials" {
 
 # GET /api/tenancy/v1/admin/tenants/{tenantId}/audit-summary
 resource "aws_api_gateway_method" "fetch_tenant_audit_summary" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenant_audit_summary[0].id
@@ -398,6 +402,7 @@ resource "aws_api_gateway_integration" "fetch_tenant_audit_summary" {
 
 # GET /api/tenancy/v1/admin/tenants/{tenantId}/diagnostics
 resource "aws_api_gateway_method" "fetch_tenant_diagnostics" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenant_diagnostics[0].id
@@ -420,6 +425,7 @@ resource "aws_api_gateway_integration" "fetch_tenant_diagnostics" {
 
 # GET /api/tenancy/v1/admin/tenants/{tenantId}/timeline
 resource "aws_api_gateway_method" "fetch_tenant_timeline" {
+  # checkov:skip=CKV2_AWS_53: HTTP_PROXY tenant-admin validation is enforced in the proxy Lambda, including Rule 14.1 tenant-scope checks
   count         = var.enable_bff ? 1 : 0
   rest_api_id   = aws_api_gateway_rest_api.bff[0].id
   resource_id   = aws_api_gateway_resource.tenant_timeline[0].id

--- a/terraform/tests/validation/test_bff_checkov_intentional_defaults.py
+++ b/terraform/tests/validation/test_bff_checkov_intentional_defaults.py
@@ -18,6 +18,18 @@ def test_bff_checkov_intentional_default_skips_are_explicit_and_scoped():
     assert "checkov:skip=CKV_AWS_120" in apigw_tf
     assert "checkov:skip=CKV_AWS_225" in apigw_tf
     assert apigw_tf.count("checkov:skip=CKV_AWS_59") == 2
+    assert apigw_tf.count("checkov:skip=CKV2_AWS_53") == 9
+    assert "Rule 14.1 tenant-scope checks" in apigw_tf
+
+    for method_name in (
+        "create_tenant",
+        "suspend_tenant",
+        "rotate_tenant_credentials",
+        "fetch_tenant_audit_summary",
+        "fetch_tenant_diagnostics",
+        "fetch_tenant_timeline",
+    ):
+        assert f'resource "aws_api_gateway_method" "{method_name}" {{\n  # checkov:skip=CKV2_AWS_53:' in apigw_tf
 
     assert "checkov:skip=CKV_AWS_310" in cloudfront_tf
     assert "checkov:skip=CKV_AWS_374" in cloudfront_tf
@@ -36,8 +48,10 @@ def test_bff_readme_documents_issue_78_classification_and_issue_79_hardening_han
     assert "CKV_AWS_225" in readme
     assert "CKV_AWS_237" in readme
     assert "CKV_AWS_59" in readme
+    assert "CKV2_AWS_53" in readme
     assert "CKV_AWS_310" in readme
     assert "CKV_AWS_374" in readme
+    assert "#91" in readme
     assert "#79" in readme
     assert "CKV_AWS_86" in readme
     assert "CKV_AWS_50" in readme


### PR DESCRIPTION
Closes #91

## Summary
- add scoped `checkov:skip=CKV2_AWS_53` exceptions to the six BFF tenant-admin API Gateway methods in `terraform/modules/agentcore-bff/apigateway.tf`
- document the tenant-admin `CKV2_AWS_53` exception rationale (Issue #91) in the BFF module README Checkov classification section
- extend targeted validation tests to enforce the new scoped skips and README documentation

## Validation
- `python3 -m pytest -q terraform/tests/validation/test_bff_checkov_intentional_defaults.py terraform/tests/validation/test_checkov_bff_regression_gate.py` -> `6 passed`
- `terraform -chdir=terraform fmt -check -recursive` -> pass
- `checkov -d terraform --framework terraform --quiet --compact --config-file terraform/.checkov.yaml --output json` + `python3 terraform/scripts/ci/checkov_bff_regression_gate.py --input <json>` -> BFF regression gate PASS, `Observed BFF failed findings: 0`
- `terraform -chdir=terraform init -backend=false -input=false && terraform -chdir=terraform validate` -> attempted, local run stalled during provider install at `Installing hashicorp/aws v6.33.0...` (no validation result captured)

## Scope / Touched Paths
- `terraform/modules/agentcore-bff/apigateway.tf`
- `terraform/modules/agentcore-bff/README.md`
- `terraform/tests/validation/test_bff_checkov_intentional_defaults.py`
