### PR TITLE
#93 Fix BFF tenancy dispatch and CloudFront logging ACL compatibility

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -107,12 +107,7 @@ Notes:
 - PASS criteria are configurable (`--min-stream-seconds`, `--min-delta-events`, `--allow-non-ndjson`).
 - If Terraform outputs are unavailable in the current worktree, pass `--url https://.../chat` explicitly.
 
-#### Frontend Component Library (React + Tailwind, No Bundler)
-To verify the committed typed client matches the current OpenAPI spec (drift check used in CI):
-
-```bash
-make check-openapi-client
-```
+#### OpenAPI Contract Diff Summary (Issue #51)
 
 To generate a human-readable OpenAPI contract diff/changelog summary against a baseline spec (for PR review or release notes prep):
 
@@ -133,26 +128,6 @@ Generated artifacts:
 
 The OpenAPI contract diff/changelog summary is generated on demand (local via `make openapi-contract-diff`) and in CI as a job summary for PR/tag review. It is not committed as a static artifact.
 
-These artifacts can be used by the Web UI and integrators to consume a consistent tool-calling contract without ad hoc request code.
-
-#### Streaming Load Tester (Issue #32)
-
-For deployed BFF environments, use the automated streaming load tester to validate the 15-minute (900s) response-streaming path and capture evidence for issue/PR closeout:
-
-```bash
-# Direct API Gateway invoke URL (terraform output agentcore_bff_api_url + /chat)
-make streaming-load-test ARGS='--session-cookie tenant-a:session-123 --duration-seconds 900 --json-summary --verbose'
-
-# CloudFront path (/api/chat) instead of direct API Gateway
-make streaming-load-test ARGS='--use-spa-url --session-cookie tenant-a:session-123 --duration-seconds 900'
-```
-
-Notes:
-- The tester sends a default prompt that instructs a long-running mock tool to emit heartbeat updates.
-- Override with `--prompt "..."` if your test agent uses a different mock tool contract.
-- PASS criteria are configurable (`--min-stream-seconds`, `--min-delta-events`, `--allow-non-ndjson`).
-- If Terraform outputs are unavailable in the current worktree, pass `--url https://.../chat` explicitly.
-
 #### Frontend Component Library (React + Tailwind, No Bundler)
 
 The SPA template and the integrated example now ship with a reusable frontend component library:
@@ -168,6 +143,7 @@ The library is intentionally static-hosting friendly:
 
 To customize a specialized dashboard, compose panels in `frontend/app.js` and keep shared primitives in `frontend/components.js`. The example app will try to load `docs/api/mcp-tools-v1.openapi.json` so issue `#33` OpenAPI output can drive tool panels, and issue `#51` adds a generated typed client at `docs/api/mcp-tools-v1.client.ts` for integrator/frontend SDK usage.
 
+```bash
 # Syntax validation
 terraform validate
 

--- a/terraform/modules/agentcore-bff/cloudfront.tf
+++ b/terraform/modules/agentcore-bff/cloudfront.tf
@@ -84,6 +84,10 @@ resource "aws_cloudfront_distribution" "bff" {
   # checkov:skip=CKV_AWS_374: Intentional harness default; geo restrictions are workload policy choices and typically enforced in WAF
   count = var.enable_bff ? 1 : 0
 
+  depends_on = [
+    aws_s3_bucket_acl.spa
+  ]
+
   # Optional WAFv2 CLOUDFRONT-scope Web ACL association (must be in us-east-1)
   web_acl_id = var.cloudfront_waf_acl_arn != "" ? var.cloudfront_waf_acl_arn : null
 

--- a/terraform/modules/agentcore-bff/data.tf
+++ b/terraform/modules/agentcore-bff/data.tf
@@ -51,6 +51,7 @@ resource "aws_s3_bucket" "spa" {
 # CloudFront standard logging (distribution logging_config) requires an ACL-enabled
 # S3 destination bucket, so keep SPA fallback bucket ACL-compatible.
 resource "aws_s3_bucket_ownership_controls" "spa" {
+  # checkov:skip=CKV2_AWS_65: CloudFront standard logging (legacy logging_config) requires ACL-compatible S3 destination buckets
   count  = var.enable_bff ? 1 : 0
   bucket = aws_s3_bucket.spa[0].id
 

--- a/terraform/modules/agentcore-bff/data.tf
+++ b/terraform/modules/agentcore-bff/data.tf
@@ -48,6 +48,28 @@ resource "aws_s3_bucket" "spa" {
   tags = var.tags
 }
 
+# CloudFront standard logging (distribution logging_config) requires an ACL-enabled
+# S3 destination bucket, so keep SPA fallback bucket ACL-compatible.
+resource "aws_s3_bucket_ownership_controls" "spa" {
+  count  = var.enable_bff ? 1 : 0
+  bucket = aws_s3_bucket.spa[0].id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "spa" {
+  count  = var.enable_bff ? 1 : 0
+  bucket = aws_s3_bucket.spa[0].id
+  acl    = "private"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.spa,
+    aws_s3_bucket_public_access_block.spa
+  ]
+}
+
 # S3 Access Logging
 resource "aws_s3_bucket_logging" "spa" {
   count  = var.enable_bff && var.logging_bucket_id != null && var.logging_bucket_id != "" ? 1 : 0

--- a/terraform/modules/agentcore-foundation/s3.tf
+++ b/terraform/modules/agentcore-foundation/s3.tf
@@ -10,6 +10,28 @@ resource "aws_s3_bucket" "access_logs" {
   tags = var.tags
 }
 
+# CloudFront standard logging (legacy S3 delivery via distribution logging_config)
+# requires ACLs to be enabled on the destination bucket.
+resource "aws_s3_bucket_ownership_controls" "access_logs" {
+  count  = var.enable_observability ? 1 : 0
+  bucket = aws_s3_bucket.access_logs[0].id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "access_logs" {
+  count  = var.enable_observability ? 1 : 0
+  bucket = aws_s3_bucket.access_logs[0].id
+  acl    = "private"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.access_logs,
+    aws_s3_bucket_public_access_block.access_logs
+  ]
+}
+
 # Block public access
 resource "aws_s3_bucket_public_access_block" "access_logs" {
   count  = var.enable_observability ? 1 : 0

--- a/terraform/modules/agentcore-foundation/s3.tf
+++ b/terraform/modules/agentcore-foundation/s3.tf
@@ -13,6 +13,7 @@ resource "aws_s3_bucket" "access_logs" {
 # CloudFront standard logging (legacy S3 delivery via distribution logging_config)
 # requires ACLs to be enabled on the destination bucket.
 resource "aws_s3_bucket_ownership_controls" "access_logs" {
+  # checkov:skip=CKV2_AWS_65: CloudFront standard logging (legacy logging_config) requires ACL-compatible S3 destination buckets
   count  = var.enable_observability ? 1 : 0
   bucket = aws_s3_bucket.access_logs[0].id
 

--- a/terraform/tests/validation/test_senior_remediation.py
+++ b/terraform/tests/validation/test_senior_remediation.py
@@ -117,14 +117,25 @@ def test_s3_access_logging():
             raise Exception("FAILED: Centralized logging bucket missing from foundation")
         if '"logging.s3.amazonaws.com"' not in content:
             raise Exception("FAILED: S3 logging service principal missing from bucket policy")
+        if 'resource "aws_s3_bucket_ownership_controls" "access_logs"' not in content:
+            raise Exception("FAILED: Foundation logging bucket ownership controls missing (CloudFront logging ACL compatibility)")
+        if 'object_ownership = "BucketOwnerPreferred"' not in content:
+            raise Exception("FAILED: ACL-compatible ownership mode missing for logging buckets")
+        if 'resource "aws_s3_bucket_acl" "access_logs"' not in content:
+            raise Exception("FAILED: Foundation logging bucket ACL resource missing (CloudFront logging compatibility)")
 
     with open(runtime_s3_path, "r") as f:
         if 'resource "aws_s3_bucket_logging" "deployment"' not in f.read():
             raise Exception("FAILED: Access logging missing from deployment bucket")
 
     with open(bff_data_path, "r") as f:
-        if 'resource "aws_s3_bucket_logging" "spa"' not in f.read():
+        content = f.read()
+        if 'resource "aws_s3_bucket_logging" "spa"' not in content:
             raise Exception("FAILED: Access logging missing from SPA bucket")
+        if 'resource "aws_s3_bucket_ownership_controls" "spa"' not in content:
+            raise Exception("FAILED: SPA bucket ownership controls missing (CloudFront logging fallback compatibility)")
+        if 'resource "aws_s3_bucket_acl" "spa"' not in content:
+            raise Exception("FAILED: SPA bucket ACL resource missing (CloudFront logging fallback compatibility)")
 
     print("  PASS: Centralized S3 Access Logging verified.")
 


### PR DESCRIPTION
Closes #93

## Summary
- fix BFF tenancy admin route dispatch in `proxy.js` (GET + POST tenancy routes no longer fall through to chat)
- enforce tenant path vs authorizer tenant isolation checks for tenant-targeted admin routes
- add/expand tenancy admin proxy tests (dispatch, 403 mismatch/missing tenant, 404 unsupported route, request validation)
- make CloudFront standard logging destinations ACL-compatible (BFF SPA fallback bucket + foundation access logs bucket)
- add CloudFront distribution dependency on SPA bucket ACL for logging setup ordering
- tighten senior remediation validation test for logging ACL compatibility
- repair duplicated sections and broken fenced block in `DEVELOPER_GUIDE.md`

## Validation
- `make preflight-session` ✅ (run at worktree start, pre-commit, and pre-push)
- `node -c terraform/modules/agentcore-bff/src/proxy.js` ✅
- `node -c terraform/modules/agentcore-bff/src/proxy.test.js` ✅
- `pytest -q terraform/tests/validation/test_senior_remediation.py` ✅ (`8 passed`)
- `terraform -chdir=terraform fmt -check -recursive` ✅
- `npm install --no-save` (for local Jest deps) ✅
- `timeout 20s npm test -- proxy.test.js --runInBand` ⚠️ hangs after Jest startup in this environment (timed out with exit `124`)
