### PR TITLE
feat: add portal diagnostics and audit timeline UI

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -141,7 +141,7 @@ The library is intentionally static-hosting friendly:
 - Tailwind is loaded via CDN
 - Components are plain reusable blocks (`AppShell`, `Panel`, `MetricCard`, `Transcript`, `Timeline`, `ToolCatalog`, etc.)
 
-To customize a specialized dashboard, compose panels in `frontend/app.js` and keep shared primitives in `frontend/components.js`. The example app will try to load `docs/api/mcp-tools-v1.openapi.json` so issue `#33` OpenAPI output can drive tool panels, and issue `#51` adds a generated typed client at `docs/api/mcp-tools-v1.client.ts` for integrator/frontend SDK usage.
+To customize a specialized dashboard, compose panels in `frontend/app.js` and keep shared primitives in `frontend/components.js`. The integrated example now demonstrates a tenant-operations portal that calls the tenancy admin diagnostics/audit/timeline endpoints and tries to load `docs/api/tenancy-admin-v1.openapi.json` (with MCP OpenAPI fallback) so API panels can be driven from the contract. Issue `#51` also adds a generated typed client at `docs/api/mcp-tools-v1.client.ts` for integrator/frontend SDK usage.
 
 ```bash
 # Syntax validation

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The SPA frontend template now includes a reusable, static-hosting-compatible com
 
 - **Runtime model:** Browser-loaded React + Tailwind (ES modules, no bundler required)
 - **Reusable blocks:** App shell, panels, metric cards, transcript, timeline, tool catalog, JSON preview, prompt composer
-- **DX integration:** The example app attempts to load `docs/api/mcp-tools-v1.openapi.json` to populate dashboard tool panels automatically, and the repo now also ships a generated typed client at `docs/api/mcp-tools-v1.client.ts` for frontend/integrator SDK usage
+- **DX integration:** The integrated example portal UI consumes the tenancy admin diagnostics/audit/timeline endpoints (`/api/tenancy/v1/admin/tenants/{tenantId}/*`) and attempts to load `docs/api/tenancy-admin-v1.openapi.json` (with MCP OpenAPI fallback) to populate API panels automatically. The repo also ships a generated typed client at `docs/api/mcp-tools-v1.client.ts` for frontend/integrator SDK usage.
 
 This keeps the BFF/Token Handler deployment model serverless and static while giving teams a composable UI base for role-specific consoles.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,7 @@ This document outlines planned features and improvements for the Bedrock AgentCo
   * Align CloudFront caching behavior/comments for SPA assets vs `index.html`.
   * **Issue:** #48
 
-- [ ] **C5: Portal Diagnostics + Audit Timeline UI**
+- [x] **C5: Portal Diagnostics + Audit Timeline UI**
   * Add portal UI views/components for tenant diagnostics and audit timeline consumption.
   * Consume the operational UX API payloads after C3 endpoint work is complete.
   * Leverage existing OpenAPI/component-library DX outputs where applicable.


### PR DESCRIPTION
## Summary
- add tenant portal UI panels in the integrated frontend example for diagnostics, audit summary, and timeline endpoints
- reuse the existing component library and OpenAPI catalog loading (tenancy admin spec first, MCP fallback)
- update README/DEVELOPER_GUIDE and mark ROADMAP C5 complete

## Validation
- node --check examples/5-integrated/frontend/app.js
- node --check examples/5-integrated/frontend/components.js
- python3 -m pytest -q terraform/tests/validation/test_tenancy_admin_api_contract_v1.py
- git diff --check
- make preflight-session (run before edits and again before commit/push)

Closes #50