### PR TITLE
C6: Harden portal session expiry and scope-mismatch UX

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -143,6 +143,8 @@ The library is intentionally static-hosting friendly:
 
 To customize a specialized dashboard, compose panels in `frontend/app.js` and keep shared primitives in `frontend/components.js`. The integrated example now demonstrates a tenant-operations portal that calls the tenancy admin diagnostics/audit/timeline endpoints and tries to load `docs/api/tenancy-admin-v1.openapi.json` (with MCP OpenAPI fallback) so API panels can be driven from the contract. Issue `#51` also adds a generated typed client at `docs/api/mcp-tools-v1.client.ts` for integrator/frontend SDK usage.
 
+Portal UX note: the integrated tenant-operations portal now classifies auth failures into session-expiry vs tenant/app scope-mismatch states, shows explicit re-auth/retry affordances, and renders sanitized user-facing auth/API errors instead of raw backend payload text.
+
 ```bash
 # Syntax validation
 terraform validate

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ The SPA frontend template now includes a reusable, static-hosting-compatible com
 - **Runtime model:** Browser-loaded React + Tailwind (ES modules, no bundler required)
 - **Reusable blocks:** App shell, panels, metric cards, transcript, timeline, tool catalog, JSON preview, prompt composer
 - **DX integration:** The integrated example portal UI consumes the tenancy admin diagnostics/audit/timeline endpoints (`/api/tenancy/v1/admin/tenants/{tenantId}/*`) and attempts to load `docs/api/tenancy-admin-v1.openapi.json` (with MCP OpenAPI fallback) to populate API panels automatically. The repo also ships a generated typed client at `docs/api/mcp-tools-v1.client.ts` for frontend/integrator SDK usage.
+- **Portal auth UX:** The integrated portal presents explicit user-facing states for session expiry vs tenant/app scope mismatch, with re-auth and retry affordances, and avoids rendering raw backend auth/API error payloads directly in the UI.
 
 This keeps the BFF/Token Handler deployment model serverless and static while giving teams a composable UI base for role-specific consoles.
 

--- a/terraform/tests/frontend/accessibility.spec.js
+++ b/terraform/tests/frontend/accessibility.spec.js
@@ -3,7 +3,7 @@ const AxeBuilder = require('@axe-core/playwright').default;
 
 test.describe('Accessibility Regression Tests', () => {
   test('component preview page should have no automatically detectable accessibility violations', async ({ page }) => {
-    await page.goto('/preview.html');
+    await page.goto('/terraform/tests/frontend/preview/preview.html');
 
     // Wait for the React app to hydrate and render.
     // We check for the presence of the AppShell title.

--- a/terraform/tests/frontend/playwright.config.js
+++ b/terraform/tests/frontend/playwright.config.js
@@ -18,7 +18,7 @@ module.exports = defineConfig({
     },
   ],
   webServer: {
-    command: 'npx http-server ./preview -p 8080',
+    command: 'npx http-server ../../.. -p 8080',
     port: 8080,
     reuseExistingServer: !process.env.CI,
   },

--- a/terraform/tests/frontend/portal-auth-ux.spec.js
+++ b/terraform/tests/frontend/portal-auth-ux.spec.js
@@ -1,0 +1,124 @@
+const { test, expect } = require('@playwright/test');
+
+const PORTAL_URL = '/examples/5-integrated/frontend/index.html';
+
+async function openPortal(page) {
+  await page.goto(PORTAL_URL);
+  await expect(page.locator('h1')).toContainText('AgentCore Tenant Operations Portal');
+  await expect(page.getByRole('button', { name: 'Diagnostics' })).toBeVisible();
+}
+
+test.describe('Tenant Portal Auth UX', () => {
+  test('shows explicit session-expiry UX and retry affordance for portal requests', async ({ page }) => {
+    let diagnosticsCalls = 0;
+    await page.route('**/api/tenancy/v1/admin/tenants/**/diagnostics', async (route) => {
+      diagnosticsCalls += 1;
+      if (diagnosticsCalls === 1) {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: 'Session expired while refreshing token for tenant admin route (internal detail should not be shown)',
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          health: 'HEALTHY',
+          generatedAt: '2026-02-25T12:00:00Z',
+          policyVersion: 'v7',
+          appId: 'portal-prod',
+          lastDeploymentSha: '1234567890abcdef',
+          memoryUsage: { usedBytes: 2048, summary: '2 KB used' },
+        }),
+      });
+    });
+
+    await openPortal(page);
+    await page.getByRole('button', { name: 'Diagnostics' }).click();
+
+    await expect(page.getByText('Session Expired')).toBeVisible();
+    await expect(page.getByText(/sign in again, then retry/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Retry Diagnostics / })).toBeVisible();
+    await expect(
+      page.getByText('Authentication required: your portal session expired or is invalid. Sign in again and retry.'),
+    ).toBeVisible();
+    await expect(page.getByText('internal detail should not be shown')).toHaveCount(0);
+
+    await page.getByRole('button', { name: /^Retry Diagnostics / }).click();
+
+    await expect(page.getByText('Session Expired')).toHaveCount(0);
+    await expect(page.getByText('HEALTHY')).toBeVisible();
+    await expect.poll(() => diagnosticsCalls).toBe(2);
+  });
+
+  test('shows scope-mismatch messaging without leaking backend isolation error text', async ({ page }) => {
+    await page.route('**/api/tenancy/v1/admin/tenants/**/diagnostics', async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Tenant isolation violation: path tenant does not match authenticated tenant',
+        }),
+      });
+    });
+
+    await openPortal(page);
+    await page.getByRole('button', { name: 'Diagnostics' }).click();
+
+    await expect(page.getByText('Tenant/App Scope Mismatch')).toBeVisible();
+    await expect(
+      page.getByText('Access denied: selected tenant/app scope does not match the authenticated session.'),
+    ).toBeVisible();
+    await expect(page.getByText('Tenant isolation violation: path tenant does not match authenticated tenant')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /^Retry Diagnostics / })).toBeVisible();
+  });
+
+  test('distinguishes non-auth API failures from auth failures with sanitized messaging', async ({ page }) => {
+    await page.route('**/api/tenancy/v1/admin/tenants/**/diagnostics', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Unhandled exception stack trace should not be rendered in the portal',
+        }),
+      });
+    });
+
+    await openPortal(page);
+    await page.getByRole('button', { name: 'Diagnostics' }).click();
+
+    await expect(page.getByText('Session Expired')).toHaveCount(0);
+    await expect(page.getByText('Tenant/App Scope Mismatch')).toHaveCount(0);
+    await expect(page.getByText(/Diagnostics acme-finance request failed \(HTTP 500\)\./)).toBeVisible();
+    await expect(page.getByText('Unhandled exception stack trace should not be rendered in the portal')).toHaveCount(0);
+  });
+
+  test('restores the chat prompt after auth failure and shows scope-mismatch chat messaging', async ({ page }) => {
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: 'Session isolation violation: tenant mismatch',
+        }),
+      });
+    });
+
+    await openPortal(page);
+    await page.getByLabel('Prompt').fill('Run tenant diagnostics and summarize anomalies');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    await expect(
+      page.getByText('Access denied: tenant/app scope mismatch. Sign in with the correct role or tenant context, then retry.'),
+    ).toBeVisible();
+    await expect(page.getByText('Session isolation violation: tenant mismatch')).toHaveCount(0);
+    await expect(page.getByText('Tenant/App Scope Mismatch')).toBeVisible();
+    await page.getByRole('button', { name: 'Restore Prompt' }).click();
+    await expect(page.getByLabel('Prompt')).toHaveValue('Run tenant diagnostics and summarize anomalies');
+  });
+});


### PR DESCRIPTION
## Summary
- harden the integrated tenant portal UX for auth failures by classifying session expiry vs tenant/app scope mismatch
- add explicit re-auth/retry affordances and sanitize user-facing auth/API error messages
- add Playwright portal auth UX coverage and update frontend test server path/docs

## Validation
- `make preflight-session` ✅ (run at session start and before commit)
- `node --check examples/5-integrated/frontend/app.js` ✅
- `node --check terraform/tests/frontend/portal-auth-ux.spec.js` ✅
- `node --check terraform/tests/frontend/playwright.config.js` ✅
- `node --check terraform/tests/frontend/accessibility.spec.js` ✅
- `npm ci` in `terraform/tests/frontend` ✅
- `npx playwright test accessibility.spec.js portal-auth-ux.spec.js` ⚠️ blocked locally: Chromium launch failed (`libnspr4.so` missing in host environment)

## Issue
Closes #62
