### PR TITLE
ci: add github frontend playwright smoke workflow post-accessibility

### DIFF
--- a/.github/workflows/frontend-playwright-smoke.yml
+++ b/.github/workflows/frontend-playwright-smoke.yml
@@ -1,0 +1,50 @@
+name: Frontend Playwright Smoke
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'examples/5-integrated/frontend/**'
+      - 'terraform/tests/frontend/**'
+      - '.github/workflows/frontend-playwright-smoke.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'examples/5-integrated/frontend/**'
+      - 'terraform/tests/frontend/**'
+      - '.github/workflows/frontend-playwright-smoke.yml'
+
+jobs:
+  playwright-smoke:
+    name: "Playwright Smoke Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: terraform/tests/frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: terraform/tests/frontend
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: terraform/tests/frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: terraform/tests/frontend
+        run: npm run test:frontend
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: terraform/tests/frontend/playwright-report/
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Frontend Playwright Smoke test workflow (`.github/workflows/frontend-playwright-smoke.yml`) for PR and main branch validation (Issue #101).
 - Policy and tag conformance report generation via `make policy-report` (Issue #61).
 - Automated IAM wildcard and tag taxonomy inventory script `terraform/scripts/generate_policy_conformance_report.py`.
 - Baseline governance report published at `docs/POLICY_CONFORMANCE_REPORT.md`.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -486,6 +486,7 @@ pre-commit run --all-files
 
 ### GitHub Actions (validation only)
 - Runs docs/tests gate, Terraform fmt/validate, TFLint, Checkov, and example validation.
+- Runs `Frontend Playwright Smoke` tests on PRs and pushes to main affecting frontend or test paths.
 - Uses `terraform init -backend=false` on the runner (local only, no AWS).
 - Uses shared GitHub Actions for Terraform, TFLint, and Checkov setup plus caching.
 - Caches Terraform plugins, TFLint plugins, and pip downloads to speed CI runs.

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ resource "gitlab_project_protected_environment" "production" {
 
 ### GitHub Actions (Validation Only)
 
-The GitHub Actions workflow runs on every pull request, push to `main`, and `v*` tag push. It executes formatting checks, `terraform validate`, TFLint, Checkov, example validation, OpenAPI/documentation checks, and Copier template generation. It does not deploy to AWS and requires no cloud credentials.
+The GitHub Actions workflow runs on every pull request, push to `main`, and `v*` tag push. It executes formatting checks, `terraform validate`, TFLint, Checkov, example validation, OpenAPI/documentation checks, Copier template generation, and Frontend Playwright Smoke tests. It does not deploy to AWS and requires no cloud credentials.
 
 GitLab CI is the deployment pipeline. It runs validation/lint/test stages and then handles environment promotion gates for deploy.
 


### PR DESCRIPTION
Closes #101. Added a new GitHub Actions workflow for frontend Playwright smoke testing, updated documentation in README.md and DEVELOPER_GUIDE.md, and recorded the change in CHANGELOG.md.