### PR TITLE
feat(governance): add feature-by-region guardrails for AgentCore toggles

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -22,6 +22,18 @@ This guide covers the development workflow for contributors. For initial account
 | `lambda_architecture` | Compute architecture (`x86_64` or `arm64`). | `x86_64` |
 | `environment` | Deployment stage (`dev`, `staging`, `prod`). | `dev` |
 
+### Regional Availability Guardrails (Issue #100)
+
+AgentCore feature coverage varies by region. The framework enforces guardrails to prevent enabling features in regions where they are not yet supported.
+
+| Feature | Supported Regions (GA/Preview) |
+| :--- | :--- |
+| **Core** (Runtime, Gateway, Memory, Identity, Observability, Tools) | `us-east-1`, `us-east-2`, `us-west-2`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `eu-central-1`, `eu-west-1` |
+| **Policy Engine** (Preview) | `us-east-1`, `us-west-2`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `eu-central-1`, `eu-west-1` |
+| **Evaluations** (Preview) | `us-east-1`, `us-west-2`, `ap-southeast-2`, `eu-central-1` |
+
+If you attempt to enable a feature in an unsupported region, `terraform plan` will fail with a descriptive error message. London (`eu-west-2`) is currently NOT supported for AgentCore Runtime, Gateway, Policy, or Evaluations.
+
 Regional availability note: AgentCore feature coverage varies by region. Prefer a region that supports the specific features you plan to enable (for example Runtime, Policy, Evaluations) and verify against the current AWS AgentCore region matrix/endpoints before rollout.
 
 ## Development Workflow

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -160,6 +160,21 @@ evaluation_type    = "TOOL_CALL"  # TOOL_CALL, REASONING, RESPONSE, ALL
 evaluator_model_id = "anthropic.claude-sonnet-4-5"
 ```
 
+## Regional Availability Guardrails (Issue #100)
+
+The framework enforces feature availability by region to prevent deployment failures.
+
+| Region | Supported Features |
+| :--- | :--- |
+| `eu-central-1` (Frankfurt) | Core, Policy, Evaluations |
+| `eu-west-1` (Ireland) | Core, Policy |
+| `us-east-1` (N. Virginia) | Core, Policy, Evaluations |
+| `us-west-2` (Oregon) | Core, Policy, Evaluations |
+| `ap-southeast-2` (Sydney) | Core, Policy, Evaluations |
+| `eu-west-2` (London) | None (Runtime/Gateway planned) |
+
+If you enable a feature in an unsupported region, `terraform plan` will fail with a descriptive error.
+
 ## Example Deployments
 
 ### Minimal Agent (Gateway Only)

--- a/docs/POLICY_CONFORMANCE_REPORT.md
+++ b/docs/POLICY_CONFORMANCE_REPORT.md
@@ -1,5 +1,5 @@
 # Policy Conformance Report
-*Generated on: 2026-02-22 09:50:11*
+*Generated on: 2026-02-25 14:02:46*
 
 ## Executive Summary
 **Overall Status**: ✅ COMPLIANT
@@ -15,8 +15,8 @@
 ## Detailed IAM Wildcard Inventory
 | File | Line | Classification | Rationale | Status |
 |------|------|----------------|-----------|--------|
-| `terraform/modules/agentcore-foundation/gateway.tf` | 100 | logs_put_resource_policy | AWS-REQUIRED: logs:PutResourcePolicy does not support resource-level scoping | ✅ |
-| `terraform/modules/agentcore-foundation/iam.tf` | 174 | bedrock_abac_scoped | Rule 7.2: Resource-level ABAC | ✅ |
+| `terraform/modules/agentcore-foundation/gateway.tf` | 103 | logs_put_resource_policy | AWS-REQUIRED: logs:PutResourcePolicy does not support resource-level scoping | ✅ |
+| `terraform/modules/agentcore-foundation/iam.tf` | 193 | bedrock_abac_scoped | Rule 14.3 ABAC: StringEqualsIfExists is required because AWS-managed resources | ✅ |
 | `terraform/modules/agentcore-tools/iam.tf` | 81 | ec2_network_interface | AWS-REQUIRED: EC2 network interface APIs do not support resource-level scoping. | ✅ |
 | `terraform/modules/agentcore-tools/iam.tf` | 173 | ec2_network_interface | AWS-REQUIRED: EC2 network interface APIs do not support resource-level scoping. | ✅ |
 | `examples/mcp-servers/terraform/main.tf` | 229 | s3_list_all_my_buckets | AWS-REQUIRED: s3:ListAllMyBuckets does not support resource-level scoping | ✅ |

--- a/terraform/region_guardrails.tf
+++ b/terraform/region_guardrails.tf
@@ -1,0 +1,81 @@
+# Feature-by-region guardrails for AgentCore (Issue #100)
+
+locals {
+  # Amazon Bedrock AgentCore General Availability (GA) regions
+  # Includes: Runtime, Gateway, Memory, Identity, Observability, Built-in Tools
+  # Reference: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
+  agentcore_ga_regions = [
+    "us-east-1",      # N. Virginia
+    "us-east-2",      # Ohio
+    "us-west-2",      # Oregon
+    "ap-south-1",     # Mumbai
+    "ap-southeast-1", # Singapore
+    "ap-southeast-2", # Sydney
+    "ap-northeast-1", # Tokyo
+    "eu-central-1",   # Frankfurt
+    "eu-west-1"       # Ireland
+  ]
+
+  # AgentCore Policy Engine Preview regions
+  # Reference: https://aws.amazon.com/about-aws/whats-new/2025/12/amazon-bedrock-agentcore-policy-evaluations-preview/
+  agentcore_policy_regions = [
+    "us-east-1",
+    "us-west-2",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-northeast-1",
+    "eu-central-1",
+    "eu-west-1"
+  ]
+
+  # AgentCore Evaluations Preview regions
+  # Reference: https://aws.amazon.com/about-aws/whats-new/2025/12/amazon-bedrock-agentcore-policy-evaluations-preview/
+  agentcore_evaluations_regions = [
+    "us-east-1",
+    "us-west-2",
+    "ap-southeast-2",
+    "eu-central-1"
+  ]
+
+  # Derived checks for current configuration
+  agentcore_is_ga_region         = contains(local.agentcore_ga_regions, local.agentcore_region)
+  agentcore_supports_policy      = contains(local.agentcore_policy_regions, local.agentcore_region)
+  agentcore_supports_evaluations = contains(local.agentcore_evaluations_regions, local.agentcore_region)
+}
+
+resource "terraform_data" "agentcore_region_guardrails" {
+  # Use input to ensure this runs and has access to locals/variables
+  input = {
+    region             = local.agentcore_region
+    enable_gateway     = var.enable_gateway
+    enable_runtime     = var.enable_runtime
+    enable_policy      = var.enable_policy_engine
+    enable_evaluations = var.enable_evaluations
+  }
+
+  lifecycle {
+    # 1. Block core features in non-GA regions
+    precondition {
+      condition     = !(var.enable_gateway && !local.agentcore_is_ga_region)
+      error_message = "AgentCore Gateway is enabled but ${local.agentcore_region} is not a GA region for Amazon Bedrock AgentCore. Please use eu-central-1 (Frankfurt) or eu-west-1 (Ireland)."
+    }
+
+    precondition {
+      condition     = !(var.enable_runtime && !local.agentcore_is_ga_region)
+      error_message = "AgentCore Runtime is enabled but ${local.agentcore_region} is not a GA region for Amazon Bedrock AgentCore. Please use eu-central-1 (Frankfurt) or eu-west-1 (Ireland)."
+    }
+
+    # 2. Block Policy Engine in unsupported regions
+    precondition {
+      condition     = !(var.enable_policy_engine && !local.agentcore_supports_policy)
+      error_message = "AgentCore Policy Engine is enabled but is not currently supported in ${local.agentcore_region}. Please use eu-central-1 (Frankfurt) or eu-west-1 (Ireland)."
+    }
+
+    # 3. Block Evaluations in unsupported regions
+    precondition {
+      condition     = !(var.enable_evaluations && !local.agentcore_supports_evaluations)
+      error_message = "AgentCore Evaluations is enabled but is not currently supported in ${local.agentcore_region}. Please use eu-central-1 (Frankfurt)."
+    }
+  }
+}


### PR DESCRIPTION
Closes #100. This PR adds region-based guardrails using pre-conditions for AgentCore gateway, runtime, policy engine, and evaluations to ensure they are deployed only in supported regions.