### PR TITLE
fix(ci): harden release vs checkpoint tag gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Ensure tag matches VERSION and CHANGELOG
         run: |
           set -euo pipefail
+          if ! printf '%s' "${GITHUB_REF_NAME}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Release tags must match vMAJOR.MINOR.PATCH (for example v0.1.0)."
+            echo "ERROR: Non-release checkpoints must use a non-v prefix (recommended: checkpoint/<label>)."
+            exit 1
+          fi
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           REPO_VERSION="$(cat VERSION)"
           if [ "$TAG_VERSION" != "$REPO_VERSION" ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -753,6 +753,15 @@ gate:prod-from-test:
   script:
     - |
       set -euo pipefail
+      RELEASE_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
+      if [ -z "${CI_COMMIT_TAG:-}" ]; then
+        echo "ERROR: gate:prod-from-test requires CI_COMMIT_TAG."
+        exit 1
+      fi
+      if ! printf '%s' "${CI_COMMIT_TAG}" | grep -Eq "${RELEASE_TAG_REGEX}"; then
+        echo "ERROR: Prod promotion gate only applies to release tags (vMAJOR.MINOR.PATCH). Use checkpoint/* tags for checkpoints."
+        exit 1
+      fi
       echo "Checking promotion gate for tag ${CI_COMMIT_TAG:-<none>} at SHA ${CI_COMMIT_SHA}"
       PIPELINES_JSON=$(curl -sS --fail --header "JOB-TOKEN: $CI_JOB_TOKEN" \
         "$CI_API_V4_URL/projects/$CI_PROJECT_ID/pipelines?sha=$CI_COMMIT_SHA&status=success&per_page=100")
@@ -817,7 +826,8 @@ gate:prod-from-test:
       - promotion-evidence/
     expire_in: 90 days
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+    - when: never
 
 # =============================================================================
 # STAGE 12: PLAN PROD (Mandatory review before prod deploy)
@@ -854,7 +864,8 @@ plan:prod:
       - $TF_ROOT/prod-plan.txt
     expire_in: 4 hours
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+    - when: never
 
 # =============================================================================
 # STAGE 13: DEPLOY PROD (Manual - operator reviews plan output before approving)
@@ -895,7 +906,8 @@ deploy:prod:
     expire_in: 90 days
   when: manual
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+    - when: never
 
 smoke-test:prod:
   stage: smoke-test-prod
@@ -908,8 +920,9 @@ smoke-test:prod:
     - cd $TF_ROOT
     - python scripts/validate_bff.py
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
+    - when: never
 
 # =============================================================================
 # SCHEDULED: DRIFT DETECTION (all environments)

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -9,8 +9,10 @@ This guide covers the development workflow for contributors. For initial account
 - Canonical repo version lives in `VERSION`.
 - Current release line is `0.1.x`.
 - Release tags are immutable and formatted as `vMAJOR.MINOR.PATCH` (example `v0.1.0`).
+- Checkpoint tags are non-release markers and MUST use a non-`v*` prefix (recommended: `checkpoint/<label>`).
 - When bumping version, update `VERSION` and `CHANGELOG.md` in the same commit.
 - Push release refs to both remotes: `origin` (GitHub) and `gitlab` (GitLab).
+- Use `make push-tag-both TAG=v0.1.0` for releases and `make push-checkpoint-tag-both TAG=checkpoint/<label>` for checkpoints.
 
 ## Core Variables
 
@@ -487,6 +489,7 @@ pre-commit run --all-files
 ### GitHub Actions (validation only)
 - Runs docs/tests gate, Terraform fmt/validate, TFLint, Checkov, and example validation.
 - Runs `Frontend Playwright Smoke` tests on PRs and pushes to main affecting frontend or test paths.
+- `release-tag-guard` accepts only strict release tags (`vMAJOR.MINOR.PATCH`); use `checkpoint/*` for non-release checkpoints.
 - Uses `terraform init -backend=false` on the runner (local only, no AWS).
 - Uses shared GitHub Actions for Terraform, TFLint, and Checkov setup plus caching.
 - Caches Terraform plugins, TFLint plugins, and pip downloads to speed CI runs.
@@ -526,10 +529,18 @@ git push gitlab main
 **Prod**: Manual from tag
 ```bash
 # Tag the same commit SHA that passed main deploy:test + smoke-test:test
+# Release tags only: vMAJOR.MINOR.PATCH
 git tag v0.1.0
 git push origin v0.1.0
 git push gitlab v0.1.0
 # gate:prod-from-test must pass, then trigger deploy-prod manually
+```
+
+**Checkpoint tags**: Non-release markers (no GitLab prod promotion semantics)
+```bash
+# Use a non-v prefix so CI does not interpret it as a release tag
+git tag checkpoint/2026-02-25-ci-hardening
+make push-checkpoint-tag-both TAG=checkpoint/2026-02-25-ci-hardening
 ```
 
 ## Best Practices

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init plan apply destroy validate fmt lint docs clean test preflight-session worktree push-main-both push-tag-both ci-status-both streaming-load-test policy-report validate-region
+.PHONY: help init plan apply destroy validate fmt lint docs clean test preflight-session worktree push-main-both push-tag-both push-checkpoint-tag-both ci-status-both streaming-load-test policy-report validate-region
 
 # Variables
 ROOT_DIR := $(abspath .)
@@ -294,6 +294,13 @@ push-main-both: ## Push main to both origin (GitHub) and gitlab remotes
 
 push-tag-both: ## Push TAG=vX.Y.Z to both origin and gitlab remotes
 	@test -n "$(TAG)" || (echo "ERROR: Provide TAG, e.g. make push-tag-both TAG=v0.1.0" && exit 1)
+	@printf '%s\n' "$(TAG)" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$' || (echo "ERROR: Release TAG must match vMAJOR.MINOR.PATCH (e.g. v0.1.0)" && exit 1)
+	git push origin $(TAG)
+	git push gitlab $(TAG)
+
+push-checkpoint-tag-both: ## Push TAG=checkpoint/<label> to both origin and gitlab remotes (validation only, no prod promotion semantics)
+	@test -n "$(TAG)" || (echo "ERROR: Provide TAG, e.g. make push-checkpoint-tag-both TAG=checkpoint/2026-02-25-ci-checkpoint" && exit 1)
+	@printf '%s\n' "$(TAG)" | grep -Eq '^checkpoint/.+$$' || (echo "ERROR: Checkpoint TAG must match checkpoint/<label>" && exit 1)
 	git push origin $(TAG)
 	git push gitlab $(TAG)
 

--- a/terraform/tests/validation/test_github_release_tag_guard.py
+++ b/terraform/tests/validation/test_github_release_tag_guard.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GITHUB_CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_release_tag_guard_enforces_strict_release_tag_format_with_checkpoint_guidance():
+    content = GITHUB_CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "release-tag-guard:" in content
+    assert "refs/tags/v" in content
+    assert "grep -Eq '^v[0-9]+\\.[0-9]+\\.[0-9]+$'" in content
+    assert "Release tags must match vMAJOR.MINOR.PATCH" in content
+    assert "checkpoint/<label>" in content

--- a/terraform/tests/validation/test_gitlab_promotion_gate_evidence.py
+++ b/terraform/tests/validation/test_gitlab_promotion_gate_evidence.py
@@ -41,3 +41,12 @@ def test_prod_gate_requires_gate_evidence_and_test_success():
     assert 'job_success "deploy:test"' in content
     assert 'job_success "smoke-test:test"' in content
     assert "promote:dev/promote:test evidence plus deploy:test + smoke-test:test" in content
+
+
+def test_prod_jobs_are_release_tag_only_not_any_tag():
+    content = _gitlab_ci_text()
+
+    release_tag_rule = "CI_COMMIT_TAG =~ /^v[0-9]+\\.[0-9]+\\.[0-9]+$/"
+    assert content.count(release_tag_rule) >= 4
+    assert content.count("- when: never") >= 4
+    assert "Prod promotion gate only applies to release tags (vMAJOR.MINOR.PATCH)." in content


### PR DESCRIPTION
## Summary
- reserve strict `vMAJOR.MINOR.PATCH` tags for release/prod promotion semantics
- add explicit checkpoint tag guidance (`checkpoint/*`) in CI logs, docs, and Makefile helpers
- harden GitLab prod jobs to run only on release tags and add CI regression tests for tag-gating policy

## Validation
- `python3 -m pytest -q terraform/tests/validation/test_gitlab_promotion_gate_evidence.py terraform/tests/validation/test_github_release_tag_guard.py`
- `git diff --check`
- `make preflight-session`
- YAML parse sanity check (tolerant loader for GitLab `!reference`) on `.gitlab-ci.yml` and `.github/workflows/ci.yml`

Closes #105
