### PR TITLE
ci: make github examples validation a hard gate (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Validate examples (local init via script)
         run: |
           cd terraform
-          bash scripts/validate_examples.sh || echo "WARN: Examples validation skipped or failed"
+          bash scripts/validate_examples.sh
 
   template-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #102

### Summary of Changes
1.  **Modified `terraform/scripts/validate_examples.sh`**:
    *   Removed the skip logic that was bypassing validation when AWS credentials were missing.
    *   Implemented mock AWS credential injection (`AWS_ACCESS_KEY_ID=mock`, etc.) to ensure `terraform plan` initializes correctly in CI environments.
    *   Added intelligent error filtering: the script now ignores expected STS/credential errors (since we are only validating variable definitions and types) but fails on "real" Terraform errors like invalid variable values, missing required variables, or redefined attributes.
2.  **Modified `.github/workflows/ci.yml`**:
    *   Converted the `examples-validate` job into a hard gate by removing the `|| echo` fallback that previously allowed it to succeed even on failure.

### Validation Results
*   **Local Success**: Ran `bash terraform/scripts/validate_examples.sh` locally. It correctly identified all 5 examples as valid, ignoring the expected mock STS failures.
*   **Failure Detection**: Verified that introducing a real error (type mismatch or redefined attribute) correctly triggers a failure exit code (1).
*   **Preflight**: `make preflight-session` passed.

### Evidence
*   **Commit SHA**: 7198407
