### PR TITLE
feat: harden regional compatibility guidance and bedrock split validation

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -43,6 +43,16 @@ Sources:
 - https://docs.aws.amazon.com/general/latest/gr/bedrock_agentcore.html
 - https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
 
+Regional source-of-truth policy (Issue #104, checked `2026-02-25`):
+- `agentcore_region` deployability: AWS General Reference AgentCore endpoints (control + data plane), enforced by `make validate-region`.
+- AgentCore feature coverage (`enable_policy_engine`, `enable_evaluations`): AgentCore feature-region matrix, enforced by Terraform preconditions.
+- `bedrock_region` compatibility: Amazon Bedrock model support + inference profile support + cross-Region inference (CRIS) docs/IAM/SCP requirements. `make validate-region` warns on split `bedrock_region` configs but does not validate model-specific support or CRIS destination-region permissions.
+Sources:
+- https://docs.aws.amazon.com/general/latest/gr/bedrock_agentcore.html
+- https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
+- https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+
 ## Development Workflow
 
 ### Making Changes
@@ -53,6 +63,8 @@ Sources:
 
 # 2. Validate locally (NO AWS needed)
 make validate-region TFVARS=../examples/1-hello-world/terraform.tfvars
+# Optional: test an explicit Bedrock split override (warning-only guidance, not model validation)
+make validate-region TFVARS=../examples/1-hello-world/terraform.tfvars BEDROCK_REGION=eu-west-2
 cd terraform
 terraform fmt -recursive
 terraform validate

--- a/Makefile
+++ b/Makefile
@@ -211,11 +211,12 @@ test-all: test test-python ## Run all tests (Terraform + Python)
 streaming-load-test: ## Run BFF/AgentCore streaming load tester (pass ARGS='...')
 	python3 terraform/scripts/streaming_load_tester.py $(ARGS)
 
-validate-region: ## Validate AgentCore Runtime region deployability (TFVARS=... or REGION=/AGENTCORE_REGION=/BFF_REGION=...)
+validate-region: ## Validate AgentCore Runtime region deployability (TFVARS=... or REGION=/AGENTCORE_REGION=/BEDROCK_REGION=/BFF_REGION=...)
 	python3 terraform/scripts/validate_agentcore_runtime_region.py \
 		$(if $(TFVARS),--tfvars "$(TFVARS)",) \
 		$(if $(REGION),--region "$(REGION)",) \
 		$(if $(AGENTCORE_REGION),--agentcore-region "$(AGENTCORE_REGION)",) \
+		$(if $(BEDROCK_REGION),--bedrock-region "$(BEDROCK_REGION)",) \
 		$(if $(BFF_REGION),--bff-region "$(BFF_REGION)",)
 
 policy-report: ## Generate policy and tag conformance report

--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ Sources:
 - https://docs.aws.amazon.com/general/latest/gr/bedrock_agentcore.html
 - https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
 
+Region source-of-truth policy (checked `2026-02-25`):
+- `agentcore_region` deployability for this repo is gated by AWS General Reference AgentCore endpoint coverage (control + data plane) and is enforced by `make validate-region`.
+- AgentCore optional feature toggles (`Policy`, `Evaluations`) are gated by the AgentCore feature-region matrix and Terraform preconditions.
+- `bedrock_region` compatibility is a separate Bedrock concern (model availability, application inference profile support, and cross-Region inference profile/IAM/SCP requirements). `make validate-region` now warns on Bedrock split-region configs but does not prove model-specific or CRIS destination-region compatibility.
+Sources:
+- https://docs.aws.amazon.com/general/latest/gr/bedrock_agentcore.html
+- https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
+- https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+
 ### 3. Deploy
 
 ```bash

--- a/terraform/tests/validation/test_validate_agentcore_runtime_region.py
+++ b/terraform/tests/validation/test_validate_agentcore_runtime_region.py
@@ -25,7 +25,9 @@ def test_parse_simple_tfvars_reads_top_level_region_assignments(tmp_path):
             [
                 'region = "eu-west-2"',
                 'agentcore_region = ""',
+                'bedrock_region = "eu-west-1"',
                 'bff_region = "eu-central-1" # comment',
+                "enable_inference_profile = true",
                 "tags = {",
                 '  Team = "Platform"',
                 "}",
@@ -38,7 +40,9 @@ def test_parse_simple_tfvars_reads_top_level_region_assignments(tmp_path):
 
     assert values["region"] == "eu-west-2"
     assert values["agentcore_region"] == ""
+    assert values["bedrock_region"] == "eu-west-1"
     assert values["bff_region"] == "eu-central-1"
+    assert values["enable_inference_profile"] == "true"
     assert "tags" not in values
 
 
@@ -52,15 +56,44 @@ def test_resolve_regions_uses_region_when_agentcore_region_override_is_empty(tmp
     assert resolved.region == "eu-central-1"
     assert resolved.agentcore_region == "eu-central-1"
     assert resolved.agentcore_region_source == "region"
+    assert resolved.bedrock_region == "eu-central-1"
+    assert resolved.bedrock_region_source == "agentcore_region"
     assert resolved.bff_region == "eu-central-1"
+    assert resolved.enable_inference_profile is None
+
+
+def test_resolve_regions_reads_bedrock_region_override_and_inference_profile_flag(tmp_path):
+    tfvars = tmp_path / "split-bedrock.tfvars"
+    tfvars.write_text(
+        "\n".join(
+            [
+                'region = "eu-central-1"',
+                'agentcore_region = ""',
+                'bedrock_region = "eu-west-2"',
+                "enable_inference_profile = true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    args = mod.parse_args(["--tfvars", str(tfvars)])
+    resolved = mod.resolve_regions(args)
+
+    assert resolved.agentcore_region == "eu-central-1"
+    assert resolved.bedrock_region == "eu-west-2"
+    assert resolved.bedrock_region_source == "bedrock_region"
+    assert resolved.enable_inference_profile is True
 
 
 def test_run_validation_rejects_runtime_matrix_region_without_endpoint_deployability():
     resolved = mod.ResolvedRegions(
         region="eu-west-2",
         agentcore_region="eu-west-2",
+        bedrock_region="eu-west-2",
         bff_region="eu-west-2",
         agentcore_region_source="region",
+        bedrock_region_source="agentcore_region",
+        enable_inference_profile=None,
         config_path=None,
     )
 
@@ -78,8 +111,11 @@ def test_run_validation_accepts_endpoint_confirmed_runtime_region():
     resolved = mod.ResolvedRegions(
         region="eu-central-1",
         agentcore_region="eu-central-1",
+        bedrock_region="eu-central-1",
         bff_region="eu-central-1",
         agentcore_region_source="region",
+        bedrock_region_source="agentcore_region",
+        enable_inference_profile=None,
         config_path=None,
     )
 
@@ -100,6 +136,7 @@ def test_main_reports_cross_region_bff_warning(tmp_path, capsys):
             [
                 'region = "eu-central-1"',
                 'agentcore_region = ""',
+                'bedrock_region = "eu-west-2"',
                 'bff_region = "eu-west-2"',
             ]
         ),
@@ -111,4 +148,26 @@ def test_main_reports_cross_region_bff_warning(tmp_path, capsys):
 
     assert code == 0
     assert "WARNING: bff_region resolves to eu-west-2" in captured.out
+    assert "WARNING: bedrock_region resolves to eu-west-2" in captured.out
+    assert "CRIS IAM/SCP requirements" in captured.out
     assert "Config source:" in captured.out
+
+
+def test_run_validation_rejects_invalid_bedrock_region_format():
+    resolved = mod.ResolvedRegions(
+        region="eu-central-1",
+        agentcore_region="eu-central-1",
+        bedrock_region="eu-west-two",
+        bff_region="eu-central-1",
+        agentcore_region_source="region",
+        bedrock_region_source="bedrock_region",
+        enable_inference_profile=None,
+        config_path=None,
+    )
+
+    code, lines = mod.run_validation(resolved)
+    output = "\n".join(lines)
+
+    assert code == 1
+    assert "invalid region input" in output
+    assert "effective bedrock_region 'eu-west-two' is not a valid AWS region code format" in output


### PR DESCRIPTION
## Summary
- extend `make validate-region` / `validate_agentcore_runtime_region.py` to parse `bedrock_region`, validate region format, and warn on split Bedrock-region configs
- add source-backed guidance for Bedrock model/CRIS compatibility without changing the existing AgentCore runtime deployability hard-fail semantics
- document region source-of-truth policy (AgentCore endpoints vs feature matrix vs Bedrock CRIS/inference profile docs) in README, developer guide, and EU split runbook
- add unit tests for `bedrock_region` parsing, split warnings, and invalid format rejection

## Validation
- `python3 -m pytest terraform/tests/validation/test_validate_agentcore_runtime_region.py -q` ✅ (7 passed)
- `make validate-region REGION=eu-central-1 BEDROCK_REGION=eu-west-2` ✅ (pass + split-bedrock warning)
- `python3 terraform/scripts/validate_agentcore_runtime_region.py --region eu-central-1 --bedrock-region eu-west-two` ✅ (expected failure; invalid format)
- `make preflight-session` ✅ (run at session start and again before commit/push)

## Issue
Closes #104
