### PR TITLE
DX: add SDK compatibility matrix validation for example agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,3 +254,26 @@ jobs:
           cd .generated-test/terraform
           terraform init -backend=false
           terraform validate
+
+  sdk-compatibility-matrix:
+    name: SDK compatibility matrix (${{ matrix.lane }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lane:
+          - repo-floors
+          - curated-stable
+          - latest-compatible
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Harness unit test
+        if: matrix.lane == 'repo-floors'
+        run: python3 -m unittest terraform/tests/validation/test_validate_sdk_compatibility_matrix.py
+      - name: Run SDK compatibility smoke matrix lane
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: make validate-sdk-compat-matrix LANE=${{ matrix.lane }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init plan apply destroy validate fmt lint docs clean test preflight-session worktree push-main-both push-tag-both push-checkpoint-tag-both ci-status-both streaming-load-test policy-report validate-region validate-version-metadata
+.PHONY: help init plan apply destroy validate fmt lint docs clean test preflight-session worktree push-main-both push-tag-both push-checkpoint-tag-both ci-status-both streaming-load-test policy-report validate-region validate-version-metadata validate-sdk-compat-matrix
 
 # Variables
 ROOT_DIR := $(abspath .)
@@ -221,6 +221,14 @@ validate-region: ## Validate AgentCore Runtime region deployability (TFVARS=... 
 
 validate-version-metadata: ## Validate VERSION, CHANGELOG.md, and docs version metadata consistency
 	python3 terraform/scripts/validate_version_metadata.py
+
+validate-sdk-compat-matrix: ## Run SDK compatibility smoke matrix for example agents (LANE=... EXAMPLE=... ARGS='...')
+	python3 terraform/scripts/validate_sdk_compatibility_matrix.py \
+		$(if $(LANE),--lane "$(LANE)",) \
+		$(if $(EXAMPLE),--example "$(EXAMPLE)",) \
+		$(if $(REUSE_VENV),--reuse-venv,) \
+		$(if $(SKIP_PIP_UPGRADE),--skip-pip-upgrade,) \
+		$(ARGS)
 
 policy-report: ## Generate policy and tag conformance report
 	@echo "Generating policy and tag conformance report..."

--- a/README.md
+++ b/README.md
@@ -255,9 +255,24 @@ make watch   # auto-restart on file changes (inotifywait)
 
 ### The Makefile
 
-The root Makefile exposes the full development surface through forty-odd targets. `make quickstart` gets a new team member from clone to validated in under a minute. `make plan-dev` through `make plan-research` let you plan against any example configuration without remembering tfvars paths. `make validate-region` provides a non-interactive AgentCore Runtime deployability guard (and `make plan*` / `make apply*` call it automatically). `make validate-version-metadata` enforces consistency between `VERSION`, `CHANGELOG.md`, and documented version metadata before release/docs drift reaches CI. `make test-all` runs every Terraform and Python validation in sequence. `make security-scan` runs Checkov. `make logs-gateway` through `make logs-evaluator` tail CloudWatch logs per component. `make docs` regenerates terraform-docs plus MCP OpenAPI/typed-client artifacts, `make generate-openapi-client` regenerates the TypeScript SDK from the MCP OpenAPI spec, `make check-openapi-client` validates generated-client drift, and `make openapi-contract-diff OLD=<baseline.json>` produces a classified contract diff/changelog summary (potentially breaking vs additive vs documentation-only) for PR/release review. `make streaming-load-test` runs the automated NDJSON streaming connectivity/load tester for validating the 15-minute (900s) streaming wall through the BFF proxy. `make debug` runs a plan with `TF_LOG=DEBUG` for when things go sideways.
+The root Makefile exposes the full development surface through forty-odd targets. `make quickstart` gets a new team member from clone to validated in under a minute. `make plan-dev` through `make plan-research` let you plan against any example configuration without remembering tfvars paths. `make validate-region` provides a non-interactive AgentCore Runtime deployability guard (and `make plan*` / `make apply*` call it automatically). `make validate-version-metadata` enforces consistency between `VERSION`, `CHANGELOG.md`, and documented version metadata before release/docs drift reaches CI. `make validate-sdk-compat-matrix` runs a fast SDK compatibility smoke matrix across example agents (Strands + Bedrock AgentCore focused) using lane labels (`repo-floors`, `curated-stable`, `latest-compatible`) with actionable lane/example failure output. `make test-all` runs every Terraform and Python validation in sequence. `make security-scan` runs Checkov. `make logs-gateway` through `make logs-evaluator` tail CloudWatch logs per component. `make docs` regenerates terraform-docs plus MCP OpenAPI/typed-client artifacts, `make generate-openapi-client` regenerates the TypeScript SDK from the MCP OpenAPI spec, `make check-openapi-client` validates generated-client drift, and `make openapi-contract-diff OLD=<baseline.json>` produces a classified contract diff/changelog summary (potentially breaking vs additive vs documentation-only) for PR/release review. `make streaming-load-test` runs the automated NDJSON streaming connectivity/load tester for validating the 15-minute (900s) streaming wall through the BFF proxy. `make debug` runs a plan with `TF_LOG=DEBUG` for when things go sideways.
 
 No target requires AWS credentials except those that explicitly deploy or read live infrastructure. Formatting, validation, security scanning, linting, and Python unit tests all run locally and offline.
+
+For dependency drift/regression checks across example agents, run:
+
+```bash
+# All lanes (repo floors, curated stable, latest-compatible resolver)
+make validate-sdk-compat-matrix
+
+# Reproduce a single failing lane/example from CI
+make validate-sdk-compat-matrix LANE=repo-floors EXAMPLE=3-deepresearch
+
+# Inspect current lane definitions and pinned package sets
+make validate-sdk-compat-matrix ARGS='--list-lanes'
+```
+
+Linux note: install Python venv support first if `python -m venv` reports missing `ensurepip` (for example `python3.12-venv` on Debian/Ubuntu).
 
 ### Streaming Wall Verification (Issue #32)
 

--- a/terraform/scripts/validate_sdk_compatibility_matrix.py
+++ b/terraform/scripts/validate_sdk_compatibility_matrix.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRATCH_ROOT = REPO_ROOT / ".scratch" / "sdk-compat-matrix"
+
+TRACKED_SDK_PACKAGES = (
+    "bedrock-agentcore",
+    "bedrock-agentcore-starter-toolkit",
+    "strands-agents",
+    "strands-agents-tools",
+    "strands-deep-agents",
+)
+
+# Curated lane is explicit/repeatable for CI regression triage. Versions are intentionally
+# conservative and should be updated when the repo floors move or maintainers re-baseline.
+CURATED_STABLE_PINS = {
+    "bedrock-agentcore": "1.0.7",
+    "bedrock-agentcore-starter-toolkit": "0.1.34",
+    "strands-agents": "1.18.0",
+    "strands-agents-tools": "0.2.16",
+    "strands-deep-agents": "0.1.1",
+    "boto3": "1.34.162",
+    "numpy": "1.26.4",
+    "pandas": "2.2.2",
+    "requests": "2.32.3",
+    "pytest": "8.3.4",
+    "pytest-asyncio": "0.24.0",
+    "pytest-cov": "5.0.0",
+    "pytest-mock": "3.14.0",
+    "moto": "5.0.28",
+    "linkup-sdk": "0.9.0",
+}
+
+REQ_LOWER_BOUND_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z0-9_.-]+)(?:\[[^\]]+\])?\s*>=\s*(?P<version>[A-Za-z0-9_.+-]+)\s*$"
+)
+
+
+@dataclass(frozen=True)
+class ExampleCheck:
+    name: str
+    path: Path
+    smoke_kind: str
+    smoke_target: str
+    install_dev: bool = True
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    name: str
+    description: str
+
+
+EXAMPLE_CHECKS = (
+    ExampleCheck(
+        name="1-hello-world",
+        path=Path("examples/1-hello-world/agent-code"),
+        smoke_kind="pytest",
+        smoke_target="tests/test_handler.py::TestHandler::test_handler_success_with_buckets",
+    ),
+    ExampleCheck(
+        name="2-gateway-tool",
+        path=Path("examples/2-gateway-tool/agent-code"),
+        smoke_kind="pytest",
+        smoke_target="tests/test_analysis.py::TestHandler::test_handler_success",
+    ),
+    ExampleCheck(
+        name="3-deepresearch",
+        path=Path("examples/3-deepresearch/agent-code"),
+        smoke_kind="pytest",
+        smoke_target="tests/integration/test_agent_creation.py::TestAgentCreation::test_detects_strands_graph",
+    ),
+    ExampleCheck(
+        name="4-research",
+        path=Path("examples/4-research/agent-code"),
+        smoke_kind="pytest",
+        smoke_target="tests/test_research_agent.py::TestHandler::test_handler_success",
+    ),
+    ExampleCheck(
+        name="5-integrated",
+        path=Path("examples/5-integrated/agent-code"),
+        smoke_kind="python",
+        smoke_target=(
+            "from runtime import handler; "
+            "result = handler({'action': 'analyze'}, None); "
+            "assert result['status'] == 'success', result"
+        ),
+    ),
+)
+
+LANE_SPECS = (
+    LaneSpec(
+        name="repo-floors",
+        description=(
+            "Exact pins derived from repo-declared minimum Strands/AgentCore SDK floors "
+            "across example pyproject files."
+        ),
+    ),
+    LaneSpec(
+        name="curated-stable",
+        description="Repo-maintained explicit pin set for reproducible CI triage and baseline coverage.",
+    ),
+    LaneSpec(
+        name="latest-compatible",
+        description="No constraints; resolve the newest versions compatible with each example's declared ranges.",
+    ),
+)
+
+
+class MatrixValidationError(RuntimeError):
+    pass
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError as exc:
+        raise ValueError(f"Unsupported non-numeric version '{version}' for floor comparison") from exc
+
+
+def _read_pyproject(root: Path, rel_path: Path) -> dict:
+    path = root / rel_path / "pyproject.toml"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing pyproject.toml for example: {path}")
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _iter_dependency_strings(pyproject: dict) -> list[str]:
+    project = pyproject.get("project", {})
+    values: list[str] = []
+    values.extend(project.get("dependencies", []) or [])
+    optional = project.get("optional-dependencies", {}) or {}
+    for extra_name in ("dev",):
+        values.extend(optional.get(extra_name, []) or [])
+    return values
+
+
+def derive_repo_floor_sdk_pins(root: Path = REPO_ROOT) -> dict[str, str]:
+    floors: dict[str, str] = {}
+    tracked = {_normalize_name(pkg) for pkg in TRACKED_SDK_PACKAGES}
+    for example in EXAMPLE_CHECKS:
+        pyproject = _read_pyproject(root, example.path)
+        for requirement in _iter_dependency_strings(pyproject):
+            match = REQ_LOWER_BOUND_RE.match(requirement)
+            if not match:
+                continue
+            name = _normalize_name(match.group("name"))
+            if name not in tracked:
+                continue
+            version = match.group("version")
+            if name not in floors or _version_key(version) > _version_key(floors[name]):
+                floors[name] = version
+
+    missing = sorted(tracked - floors.keys())
+    if missing:
+        raise MatrixValidationError(
+            "Unable to derive repo-floors lane; missing lower-bound declarations for tracked packages: "
+            + ", ".join(missing)
+        )
+    return dict(sorted(floors.items()))
+
+
+def get_lane_names() -> list[str]:
+    return [lane.name for lane in LANE_SPECS]
+
+
+def _get_example_by_name(name: str) -> ExampleCheck:
+    for example in EXAMPLE_CHECKS:
+        if example.name == name:
+            return example
+    valid = ", ".join(e.name for e in EXAMPLE_CHECKS)
+    raise MatrixValidationError(f"Unknown example '{name}'. Valid examples: {valid}")
+
+
+def _get_lane_spec(name: str) -> LaneSpec:
+    for lane in LANE_SPECS:
+        if lane.name == name:
+            return lane
+    valid = ", ".join(get_lane_names())
+    raise MatrixValidationError(f"Unknown lane '{name}'. Valid lanes: {valid}")
+
+
+def get_lane_pins(lane_name: str, root: Path = REPO_ROOT) -> dict[str, str]:
+    if lane_name == "repo-floors":
+        return derive_repo_floor_sdk_pins(root)
+    if lane_name == "curated-stable":
+        return dict(sorted(CURATED_STABLE_PINS.items()))
+    if lane_name == "latest-compatible":
+        return {}
+    _get_lane_spec(lane_name)
+    raise AssertionError("unreachable")
+
+
+def _format_constraints_lines(pins: dict[str, str]) -> list[str]:
+    return [f"{name}=={pins[name]}" for name in sorted(pins)]
+
+
+def write_constraints_file(lane_name: str, workspace: Path, root: Path = REPO_ROOT) -> Path | None:
+    pins = get_lane_pins(lane_name, root=root)
+    if not pins:
+        return None
+    constraints_path = workspace / f"{lane_name}.constraints.txt"
+    lines = _format_constraints_lines(pins)
+    constraints_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return constraints_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run fast SDK compatibility smoke checks for example agents across version lanes "
+            "(Strands + Bedrock AgentCore focus)."
+        )
+    )
+    parser.add_argument(
+        "--lane",
+        dest="lanes",
+        action="append",
+        help=f"Lane to run (repeatable). Valid: {', '.join(get_lane_names())}. Defaults to all lanes.",
+    )
+    parser.add_argument(
+        "--example",
+        dest="examples",
+        action="append",
+        help="Example to run (repeatable). Defaults to all configured examples.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=SCRATCH_ROOT,
+        help="Scratch working directory for venvs/constraints (default: .scratch/sdk-compat-matrix).",
+    )
+    parser.add_argument(
+        "--list-lanes",
+        action="store_true",
+        help="Print lane names, descriptions, and current pin sets (if any), then exit.",
+    )
+    parser.add_argument(
+        "--reuse-venv",
+        action="store_true",
+        help="Reuse per-lane virtualenvs if present (local speed optimization). CI should not use this.",
+    )
+    parser.add_argument(
+        "--skip-pip-upgrade",
+        action="store_true",
+        help="Skip upgrading pip/setuptools/wheel in each lane venv.",
+    )
+    return parser.parse_args(argv)
+
+
+def _select_lanes(requested: list[str] | None) -> list[str]:
+    if not requested:
+        return get_lane_names()
+    seen: list[str] = []
+    for lane in requested:
+        _get_lane_spec(lane)
+        if lane not in seen:
+            seen.append(lane)
+    return seen
+
+
+def _select_examples(requested: list[str] | None) -> list[ExampleCheck]:
+    if not requested:
+        return list(EXAMPLE_CHECKS)
+    selected: list[ExampleCheck] = []
+    seen: set[str] = set()
+    for name in requested:
+        example = _get_example_by_name(name)
+        if example.name in seen:
+            continue
+        seen.add(example.name)
+        selected.append(example)
+    return selected
+
+
+def _print_lanes(root: Path) -> None:
+    print("SDK compatibility matrix lanes:")
+    for lane in LANE_SPECS:
+        print(f"- {lane.name}: {lane.description}")
+        pins = get_lane_pins(lane.name, root=root)
+        if not pins:
+            print("  pins: none (resolver latest-compatible)")
+            continue
+        for line in _format_constraints_lines(pins):
+            print(f"  {line}")
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    label: str,
+) -> None:
+    print(f"[{label}] RUN: {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, cwd=cwd, env=env, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise MatrixValidationError(f"{label}: command failed with exit code {exc.returncode}") from exc
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _prepare_venv(
+    *,
+    lane_name: str,
+    lane_workspace: Path,
+    reuse_venv: bool,
+    skip_pip_upgrade: bool,
+) -> Path:
+    venv_dir = lane_workspace / "venv"
+    try:
+        import ensurepip  # noqa: F401
+    except ImportError as exc:
+        raise MatrixValidationError(
+            f"lane={lane_name}: Python venv support is unavailable (ensurepip missing). "
+            "Install the OS venv package (for example `python3.12-venv` on Debian/Ubuntu) and retry."
+        ) from exc
+    if venv_dir.exists() and not reuse_venv:
+        shutil.rmtree(venv_dir)
+    if not venv_dir.exists():
+        _run([sys.executable, "-m", "venv", str(venv_dir)], cwd=REPO_ROOT, label=f"lane={lane_name}")
+    py = _venv_python(venv_dir)
+    if not py.exists():
+        raise MatrixValidationError(f"lane={lane_name}: virtualenv python not found at {py}")
+    if not skip_pip_upgrade:
+        _run(
+            [str(py), "-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel"],
+            cwd=REPO_ROOT,
+            label=f"lane={lane_name}",
+        )
+    return py
+
+
+def _install_example(
+    *,
+    py: Path,
+    example: ExampleCheck,
+    constraints_path: Path | None,
+    lane_name: str,
+    root: Path,
+) -> None:
+    cmd = [str(py), "-m", "pip", "install"]
+    if constraints_path is not None:
+        cmd.extend(["-c", str(constraints_path)])
+    cmd.extend(["-e", ".[dev]" if example.install_dev else "."])
+    _run(cmd, cwd=root / example.path, label=f"lane={lane_name} example={example.name} install")
+
+
+def _run_smoke(*, py: Path, example: ExampleCheck, lane_name: str, root: Path) -> None:
+    if example.smoke_kind == "pytest":
+        cmd = [str(py), "-m", "pytest", "-v", "--tb=short", example.smoke_target]
+    elif example.smoke_kind == "python":
+        cmd = [str(py), "-c", example.smoke_target]
+    else:
+        raise MatrixValidationError(f"Unsupported smoke kind '{example.smoke_kind}' for {example.name}")
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    _run(cmd, cwd=root / example.path, env=env, label=f"lane={lane_name} example={example.name} smoke")
+
+
+def run_matrix(
+    *,
+    lanes: list[str],
+    examples: list[ExampleCheck],
+    work_dir: Path,
+    reuse_venv: bool,
+    skip_pip_upgrade: bool,
+    root: Path = REPO_ROOT,
+) -> int:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    failures: list[str] = []
+
+    print("SDK compatibility matrix configuration:")
+    print(f"- repo root: {root}")
+    print(f"- work dir: {work_dir}")
+    print(f"- lanes: {', '.join(lanes)}")
+    print(f"- examples: {', '.join(example.name for example in examples)}")
+
+    for lane_name in lanes:
+        lane_spec = _get_lane_spec(lane_name)
+        lane_workspace = work_dir / lane_name
+        lane_workspace.mkdir(parents=True, exist_ok=True)
+        constraints_path = write_constraints_file(lane_name, lane_workspace, root=root)
+        pins = get_lane_pins(lane_name, root=root)
+
+        print("")
+        print(f"=== LANE {lane_name} ===")
+        print(f"Description: {lane_spec.description}")
+        if pins:
+            print("Pinned packages:")
+            for line in _format_constraints_lines(pins):
+                print(f"  - {line}")
+        else:
+            print("Pinned packages: none (resolver latest-compatible)")
+
+        try:
+            py = _prepare_venv(
+                lane_name=lane_name,
+                lane_workspace=lane_workspace,
+                reuse_venv=reuse_venv,
+                skip_pip_upgrade=skip_pip_upgrade,
+            )
+            for example in examples:
+                print(f"\n--- [{lane_name}] Example {example.name} ---")
+                _install_example(
+                    py=py,
+                    example=example,
+                    constraints_path=constraints_path,
+                    lane_name=lane_name,
+                    root=root,
+                )
+                _run_smoke(py=py, example=example, lane_name=lane_name, root=root)
+        except MatrixValidationError as exc:
+            failures.append(str(exc))
+            print(f"ERROR: {exc}")
+
+    print("")
+    if failures:
+        print("SDK compatibility matrix FAILED.")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("SDK compatibility matrix PASSED.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    lanes = _select_lanes(args.lanes)
+    examples = _select_examples(args.examples)
+    root = REPO_ROOT
+
+    if args.list_lanes:
+        _print_lanes(root)
+        return 0
+
+    try:
+        return run_matrix(
+            lanes=lanes,
+            examples=examples,
+            work_dir=args.work_dir,
+            reuse_venv=args.reuse_venv,
+            skip_pip_upgrade=args.skip_pip_upgrade,
+            root=root,
+        )
+    except MatrixValidationError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/scripts/validate_sdk_compatibility_matrix.py
+++ b/terraform/scripts/validate_sdk_compatibility_matrix.py
@@ -30,7 +30,7 @@ CURATED_STABLE_PINS = {
     "strands-agents": "1.18.0",
     "strands-agents-tools": "0.2.16",
     "strands-deep-agents": "0.1.1",
-    "boto3": "1.40.52",
+    "boto3": "1.40.65",
     "numpy": "1.26.4",
     "pandas": "2.2.2",
     "requests": "2.32.3",

--- a/terraform/scripts/validate_sdk_compatibility_matrix.py
+++ b/terraform/scripts/validate_sdk_compatibility_matrix.py
@@ -30,7 +30,7 @@ CURATED_STABLE_PINS = {
     "strands-agents": "1.18.0",
     "strands-agents-tools": "0.2.16",
     "strands-deep-agents": "0.1.1",
-    "boto3": "1.34.162",
+    "boto3": "1.40.52",
     "numpy": "1.26.4",
     "pandas": "2.2.2",
     "requests": "2.32.3",

--- a/terraform/tests/validation/test_validate_sdk_compatibility_matrix.py
+++ b/terraform/tests/validation/test_validate_sdk_compatibility_matrix.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "validate_sdk_compatibility_matrix.py"
+    spec = importlib.util.spec_from_file_location("validate_sdk_compatibility_matrix", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+
+
+def _seed_example_pyproject(
+    root: Path,
+    rel_path: Path,
+    *,
+    deps: list[str],
+    dev_deps: list[str] | None = None,
+) -> None:
+    dev_deps = dev_deps or []
+    dev_lines = "\n".join(f'    "{dep}",' for dep in dev_deps) or "    # none"
+    dep_lines = "\n".join(f'    "{dep}",' for dep in deps)
+    _write(
+        root / rel_path / "pyproject.toml",
+        f"""
+        [project]
+        name = "{rel_path.parts[1]}"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+        {dep_lines}
+        ]
+
+        [project.optional-dependencies]
+        dev = [
+        {dev_lines}
+        ]
+        """,
+    )
+
+
+class ValidateSdkCompatibilityMatrixTests(unittest.TestCase):
+    def test_repo_floors_are_derived_from_maximum_declared_minimums(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Seed all configured examples so the derivation path remains realistic.
+            for example in mod.EXAMPLE_CHECKS:
+                _seed_example_pyproject(
+                    root,
+                    example.path,
+                    deps=[
+                        "bedrock-agentcore>=1.0.7",
+                        "strands-agents>=1.18.0",
+                    ],
+                    dev_deps=[],
+                )
+
+            # Override a couple of examples to force max-floor selection.
+            _seed_example_pyproject(
+                root,
+                Path("examples/3-deepresearch/agent-code"),
+                deps=[
+                    "bedrock-agentcore>=1.0.9",
+                    "strands-agents>=1.20.0",
+                    "strands-agents-tools>=0.3.0",
+                    "strands-deep-agents>=0.2.0",
+                ],
+                dev_deps=["bedrock-agentcore-starter-toolkit>=0.1.40"],
+            )
+            _seed_example_pyproject(
+                root,
+                Path("examples/5-integrated/agent-code"),
+                deps=[
+                    "bedrock-agentcore>=1.0.8",
+                    "strands-agents>=1.19.0",
+                ],
+                dev_deps=[],
+            )
+
+            floors = mod.derive_repo_floor_sdk_pins(root)
+            self.assertEqual(
+                floors,
+                {
+                    "bedrock-agentcore": "1.0.9",
+                    "bedrock-agentcore-starter-toolkit": "0.1.40",
+                    "strands-agents": "1.20.0",
+                    "strands-agents-tools": "0.3.0",
+                    "strands-deep-agents": "0.2.0",
+                },
+            )
+
+    def test_write_constraints_file_skips_latest_compatible_lane(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            self.assertIsNone(mod.write_constraints_file("latest-compatible", workspace, root=Path(tmp)))
+
+    def test_write_constraints_file_emits_curated_pins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            constraints = mod.write_constraints_file("curated-stable", workspace)
+            assert constraints is not None
+            text = constraints.read_text(encoding="utf-8")
+            self.assertIn("bedrock-agentcore==1.0.7", text)
+            self.assertIn("strands-agents==1.18.0", text)
+            self.assertIn("moto==5.0.28", text)
+
+    def test_select_lanes_deduplicates_and_validates(self):
+        lanes = mod._select_lanes(["repo-floors", "repo-floors", "curated-stable"])
+        self.assertEqual(lanes, ["repo-floors", "curated-stable"])
+        with self.assertRaises(mod.MatrixValidationError):
+            mod._select_lanes(["not-a-lane"])
+
+    def test_select_examples_deduplicates_and_validates(self):
+        examples = mod._select_examples(["1-hello-world", "1-hello-world", "5-integrated"])
+        self.assertEqual([example.name for example in examples], ["1-hello-world", "5-integrated"])
+        with self.assertRaises(mod.MatrixValidationError):
+            mod._select_examples(["bad-example"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #115

## Summary
- add a lane-based SDK compatibility smoke matrix harness for example agents (Strands + Bedrock AgentCore focus)
- add a Makefile target and GitHub Actions matrix job for CI/local execution
- document local reproduction, lane definitions, and pin maintenance workflow

## Validation
- `make preflight-session` ✅ (ran at start and before commit/push)
- `make validate-sdk-compat-matrix ARGS='--list-lanes'` ✅
- `python3 -m unittest terraform/tests/validation/test_validate_sdk_compatibility_matrix.py` ✅
- `python3 -m py_compile terraform/scripts/validate_sdk_compatibility_matrix.py` ✅
- `make validate-sdk-compat-matrix LANE=repo-floors EXAMPLE=1-hello-world` ⚠️ blocked locally: host Python lacks `ensurepip` / `python3.12-venv`; harness now emits actionable guidance. CI runner job covers full lane execution.

## Notes
- CI now runs lane-labeled jobs: `repo-floors`, `curated-stable`, `latest-compatible`.
