### PR TITLE
feat(dx): add minimal LangGraph baseline demo agent

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -124,6 +124,10 @@ python3 -m pytest tests/unit -v
 
 # Or via make (from repo root):
 make test-python-unit
+
+# LangGraph baseline smoke tests:
+cd examples/6-langgraph-baseline/agent-code
+python3 -m pytest tests/ -v
 ```
 
 #### SDK Compatibility Matrix (Issue #115)
@@ -351,6 +355,7 @@ repo-root/
 |   +-- 2-gateway-tool/   # MCP gateway with Titanic analysis
 |   +-- 3-deepresearch/   # Full Strands DeepAgents implementation
 |   +-- 4-research/       # Simplified research agent
+|   +-- 6-langgraph-baseline/ # Minimal LangGraph runtime baseline
 |
 +-- docs/                 # Documentation
 |   +-- adr/              # Architecture Decision Records

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,11 @@ generate-openapi-client: ## Generate typed TypeScript client from MCP Tools Open
 	python3 terraform/scripts/generate_mcp_typescript_client.py
 	@echo "✓ Typed client generated to docs/api/mcp-tools-v1.client.ts"
 
+report-sdk-drift: ## Generate SDK version drift report for example agents
+	@echo "Generating SDK version drift report..."
+	python3 terraform/scripts/report_sdk_drift.py
+	@echo "✓ SDK version drift report generated to docs/SDK_VERSION_DRIFT_REPORT.md"
+
 check-openapi-client: ## Verify generated MCP Tools TypeScript client matches OpenAPI spec
 	@echo "Checking MCP Tools TypeScript client drift..."
 	python3 terraform/scripts/generate_mcp_typescript_client.py --check

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ preview-frontend: ## Run a local server to preview frontend components
 	@echo "Starting component preview server on http://localhost:8080..."
 	cd terraform/tests/frontend && npm install && npx http-server ./preview -p 8080 -o
 
-# Testing - Python (All example agents)
-test-python: test-python-hello test-python-gateway test-python-deepresearch test-python-research ## Run all Python tests
+# Testing - Python (All example agents with tests)
+test-python: test-python-hello test-python-gateway test-python-deepresearch test-python-research test-python-langgraph ## Run all Python tests
 	@echo "✓ All Python tests passed"
 
 test-python-hello: ## Run hello-world agent tests
@@ -188,8 +188,13 @@ test-python-research: ## Run simple research agent tests
 	pip install -q -e ".[dev]" && \
 	python -m pytest tests/ -v --tb=short
 
+test-python-langgraph: ## Run LangGraph baseline agent tests
+	cd examples/6-langgraph-baseline/agent-code && \
+	pip install -q -e ".[dev]" && \
+	python -m pytest tests/ -v --tb=short
+
 test-python-unit: ## Run all Python unit tests
-	@for example in 1-hello-world 2-gateway-tool 4-research; do \
+	@for example in 1-hello-world 2-gateway-tool 4-research 6-langgraph-baseline; do \
 		echo "Testing $$example..."; \
 		cd examples/$$example/agent-code && pip install -q -e ".[dev]" && python -m pytest tests/ -v --tb=short && cd ../../../; \
 	done

--- a/README.md
+++ b/README.md
@@ -538,6 +538,9 @@ Operational verification points:
 | `3-deepresearch` | Full-featured research agent with Strands DeepAgents | Gateway, Code Interpreter, Browser, Memory (BOTH), Observability |
 | `4-research` | Research agent with governance and quality evaluation | Gateway, Code Interpreter, Browser, Memory, Evaluations (REASONING) |
 | `5-integrated` | Full module composition with BFF/SPA, CloudFront, and Token Handler | Gateway, Runtime, BFF, CloudFront, WAF, Memory, Evaluations, Code Interpreter |
+| `6-langgraph-baseline` | Minimal LangGraph single-agent baseline for runtime parity comparisons | Runtime, Observability, Packaging |
+
+`6-langgraph-baseline` is intentionally small and deterministic (no live model call) so teams can compare the runtime wiring and local developer workflow against the Strands examples before adding tools, memory, or governance features.
 
 Deploy any example with a single command:
 

--- a/examples/6-langgraph-baseline/README.md
+++ b/examples/6-langgraph-baseline/README.md
@@ -1,0 +1,62 @@
+# Example 6: LangGraph Baseline (Minimal)
+
+A minimal LangGraph-based AgentCore runtime example for framework parity with the FAST-style single-agent pattern.
+
+## What This Example Shows
+
+- `LangGraph` state-graph orchestration with deterministic nodes (no external model dependency)
+- `bedrock_agentcore.BedrockAgentCoreApp` runtime entrypoint integration
+- Structured JSON responses compatible with local smoke testing
+- Minimal deployment configuration following the existing example layout
+
+## Features Enabled
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Gateway | Disabled | Runtime-only baseline |
+| Code Interpreter | Disabled | Not needed |
+| Browser | Disabled | Not needed |
+| Memory | Disabled | Stateless demo |
+| Policy Engine | Disabled | Not enabled in baseline |
+| Evaluations | Disabled | Not enabled in baseline |
+| Packaging | **Enabled** | Installs `langgraph` + `bedrock-agentcore` |
+
+## Agent Behavior
+
+The graph executes three small steps:
+1. Normalize the incoming prompt
+2. Route to a tiny built-in "tool-like" capability summary node
+3. Compose a final response with steps and framework metadata
+
+This keeps the example runnable offline while still demonstrating LangGraph orchestration semantics.
+
+## Usage
+
+### Local Run
+
+```bash
+cd examples/6-langgraph-baseline/agent-code
+pip install -e ".[dev]"
+python runtime.py
+```
+
+### Local Tests
+
+```bash
+cd examples/6-langgraph-baseline/agent-code
+python -m pytest tests/ -v --tb=short
+```
+
+### Deploy to AWS
+
+```bash
+cd terraform
+terraform init
+terraform plan -var-file=../examples/6-langgraph-baseline/terraform.tfvars
+terraform apply -var-file=../examples/6-langgraph-baseline/terraform.tfvars
+```
+
+## Purpose and Limitations
+
+- Purpose: small parity/demo baseline for teams evaluating LangGraph vs Strands examples in this repo
+- Limitation: no live LLM calls, no MCP gateway, no memory, no browser/code interpreter integration

--- a/examples/6-langgraph-baseline/agent-code/pyproject.toml
+++ b/examples/6-langgraph-baseline/agent-code/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "langgraph-baseline-agent"
+version = "0.1.0"
+description = "Minimal LangGraph baseline demo for Bedrock AgentCore runtime"
+requires-python = ">=3.12"
+dependencies = [
+    "bedrock-agentcore>=1.0.7",
+    "langgraph>=0.2.0,<1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-v --tb=short"

--- a/examples/6-langgraph-baseline/agent-code/runtime.py
+++ b/examples/6-langgraph-baseline/agent-code/runtime.py
@@ -1,0 +1,151 @@
+"""
+Minimal LangGraph baseline demo for Bedrock AgentCore runtime.
+
+This example intentionally avoids live LLM calls so it can run locally without
+credentials while still demonstrating LangGraph graph construction and
+AgentCore runtime entrypoint wiring.
+"""
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any, TypedDict
+
+from bedrock_agentcore import BedrockAgentCoreApp
+from langgraph.graph import END, START, StateGraph
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger("langgraph_baseline")
+
+
+class DemoState(TypedDict, total=False):
+    """Mutable graph state for the demo workflow."""
+
+    prompt: str
+    normalized_prompt: str
+    intent: str
+    capabilities: list[str]
+    response: str
+    steps: list[str]
+
+
+def normalize_prompt(state: DemoState) -> DemoState:
+    """Normalize incoming prompt text and infer a simple intent."""
+    prompt = (state.get("prompt") or "").strip()
+    normalized = " ".join(prompt.split())
+    lowered = normalized.lower()
+    intent = "capabilities" if any(word in lowered for word in ("can", "capabilities", "help")) else "echo"
+    return {
+        "normalized_prompt": normalized or "Hello from LangGraph baseline",
+        "intent": intent,
+        "steps": [*(state.get("steps") or []), "normalize_prompt"],
+    }
+
+
+def collect_capabilities(state: DemoState) -> DemoState:
+    """Return a small deterministic capability set (tool-like node)."""
+    intent = state.get("intent", "echo")
+    if intent == "capabilities":
+        capabilities = [
+            "Deterministic LangGraph node orchestration",
+            "Bedrock AgentCore runtime entrypoint wiring",
+            "Structured JSON responses for local smoke tests",
+        ]
+    else:
+        capabilities = ["Prompt normalization", "State tracking", "Response composition"]
+    return {
+        "capabilities": capabilities,
+        "steps": [*(state.get("steps") or []), "collect_capabilities"],
+    }
+
+
+def compose_response(state: DemoState) -> DemoState:
+    """Compose the final user-facing response."""
+    prompt = state.get("normalized_prompt", "")
+    intent = state.get("intent", "echo")
+    capabilities = state.get("capabilities", [])
+    if intent == "capabilities":
+        lines = [f"- {item}" for item in capabilities]
+        response = "LangGraph baseline capabilities:\n" + "\n".join(lines)
+    else:
+        response = f"LangGraph baseline received: {prompt}"
+
+    return {
+        "response": response,
+        "steps": [*(state.get("steps") or []), "compose_response"],
+    }
+
+
+def build_graph():
+    """Compile the minimal LangGraph workflow."""
+    graph = StateGraph(DemoState)
+    graph.add_node("normalize_prompt", normalize_prompt)
+    graph.add_node("collect_capabilities", collect_capabilities)
+    graph.add_node("compose_response", compose_response)
+    graph.add_edge(START, "normalize_prompt")
+    graph.add_edge("normalize_prompt", "collect_capabilities")
+    graph.add_edge("collect_capabilities", "compose_response")
+    graph.add_edge("compose_response", END)
+    return graph.compile()
+
+
+GRAPH = build_graph()
+app = BedrockAgentCoreApp(debug=True)
+
+
+def run_agent(prompt: str) -> dict[str, Any]:
+    """Invoke the compiled graph and return structured output."""
+    state = GRAPH.invoke({"prompt": prompt})
+    return {
+        "framework": "langgraph",
+        "intent": state.get("intent", "unknown"),
+        "steps": state.get("steps", []),
+        "response": state.get("response", ""),
+        "capabilities": state.get("capabilities", []),
+    }
+
+
+@app.entrypoint
+def invoke(payload: dict[str, Any], context: Any = None) -> dict[str, Any]:
+    """AgentCore runtime entrypoint."""
+    del context  # Unused in this minimal baseline.
+
+    logger.info("LangGraph baseline invoked")
+    logger.info("Payload keys: %s", sorted((payload or {}).keys()))
+
+    try:
+        prompt = (
+            (payload or {}).get("prompt")
+            or (payload or {}).get("message")
+            or (payload or {}).get("query")
+            or "What can you do?"
+        )
+        result = run_agent(prompt=prompt)
+        return {
+            "status": "success",
+            "message": "LangGraph baseline completed",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "result": result,
+        }
+    except Exception as exc:
+        logger.exception("LangGraph baseline failed")
+        return {
+            "status": "error",
+            "message": f"LangGraph baseline failed: {exc}",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        }
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Compatibility wrapper mirroring the simpler example handlers."""
+    return invoke(event, context)
+
+
+if __name__ == "__main__":
+    sample = {"prompt": "What capabilities does this LangGraph demo show?"}
+    print(json.dumps(handler(sample, None), indent=2))

--- a/examples/6-langgraph-baseline/agent-code/tests/__init__.py
+++ b/examples/6-langgraph-baseline/agent-code/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LangGraph baseline example."""

--- a/examples/6-langgraph-baseline/agent-code/tests/conftest.py
+++ b/examples/6-langgraph-baseline/agent-code/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest fixtures for LangGraph baseline example tests."""
+
+import pytest
+
+
+@pytest.fixture
+def sample_event():
+    """Default prompt event."""
+    return {"prompt": "What can you do?"}
+
+
+@pytest.fixture
+def echo_event():
+    """Prompt that exercises the non-capabilities branch."""
+    return {"message": "Echo this back"}

--- a/examples/6-langgraph-baseline/agent-code/tests/test_langgraph_runtime.py
+++ b/examples/6-langgraph-baseline/agent-code/tests/test_langgraph_runtime.py
@@ -1,0 +1,94 @@
+"""Smoke and unit tests for the LangGraph baseline runtime."""
+
+from datetime import datetime
+
+
+def test_build_graph_compiles_and_invokes():
+    """The graph should compile and run without network calls."""
+    from runtime import build_graph
+
+    graph = build_graph()
+    result = graph.invoke({"prompt": "What can you do?"})
+
+    assert result["intent"] == "capabilities"
+    assert "response" in result
+    assert result["steps"] == ["normalize_prompt", "collect_capabilities", "compose_response"]
+
+
+def test_run_agent_returns_structured_result():
+    """run_agent should return framework metadata and steps."""
+    from runtime import run_agent
+
+    result = run_agent("What can you do?")
+
+    assert result["framework"] == "langgraph"
+    assert result["intent"] == "capabilities"
+    assert "LangGraph baseline capabilities" in result["response"]
+    assert len(result["capabilities"]) >= 1
+    assert result["steps"][-1] == "compose_response"
+
+
+def test_handler_accepts_prompt(sample_event):
+    """handler should return a success payload for a standard prompt."""
+    from runtime import handler
+
+    result = handler(sample_event, None)
+
+    assert result["status"] == "success"
+    assert result["message"] == "LangGraph baseline completed"
+    assert result["result"]["framework"] == "langgraph"
+    assert result["result"]["intent"] == "capabilities"
+
+
+def test_handler_accepts_query_alias():
+    """handler should accept the query alias used by other examples."""
+    from runtime import handler
+
+    result = handler({"query": "hello there"}, None)
+
+    assert result["status"] == "success"
+    assert result["result"]["intent"] == "echo"
+    assert "hello there" in result["result"]["response"].lower()
+
+
+def test_handler_uses_default_prompt():
+    """handler should use a default prompt when none is provided."""
+    from runtime import handler
+
+    result = handler({}, None)
+
+    assert result["status"] == "success"
+    assert result["result"]["intent"] == "capabilities"
+
+
+def test_handler_returns_iso_timestamp(sample_event):
+    """handler response should contain an ISO8601 UTC timestamp."""
+    from runtime import handler
+
+    result = handler(sample_event, None)
+
+    assert result["timestamp"].endswith("Z")
+    datetime.fromisoformat(result["timestamp"].replace("Z", "+00:00"))
+
+
+def test_handler_error_path(monkeypatch):
+    """handler should return a structured error when run_agent fails."""
+    import runtime
+
+    def _raise(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runtime, "run_agent", _raise)
+    result = runtime.handler({"prompt": "fail"}, None)
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_agentcore_app_exposes_runtime_methods():
+    """BedrockAgentCoreApp instance should expose the expected runtime hooks."""
+    from runtime import app
+
+    assert callable(app.entrypoint)
+    assert callable(app.run)

--- a/examples/6-langgraph-baseline/terraform.tfvars
+++ b/examples/6-langgraph-baseline/terraform.tfvars
@@ -1,0 +1,43 @@
+# LangGraph Baseline Example (Minimal)
+# Runtime-only baseline for framework parity and local smoke testing
+
+agent_name  = "langgraph-demo-core-k1l2"
+app_id      = "langgraph-baseline"
+region      = "us-east-1"
+environment = "dev"
+
+tags = {
+  Team    = "Platform"
+  Purpose = "Demo"
+  Example = "6-langgraph-baseline"
+}
+
+# ===== FOUNDATION =====
+enable_gateway       = false
+enable_identity      = false
+enable_observability = true
+enable_xray          = true
+
+# ===== TOOLS =====
+enable_code_interpreter = false
+enable_browser          = false
+
+# ===== RUNTIME =====
+enable_runtime      = true
+runtime_source_path = "../examples/6-langgraph-baseline/agent-code"
+runtime_entry_file  = "runtime.py"
+
+runtime_config = {
+  max_iterations  = 3
+  timeout_seconds = 60
+  framework       = "langgraph"
+}
+
+enable_memory = false
+
+enable_packaging = true
+python_version   = "3.12"
+
+# ===== GOVERNANCE =====
+enable_policy_engine = false
+enable_evaluations   = false


### PR DESCRIPTION
## Summary
- add a new `examples/6-langgraph-baseline` minimal LangGraph AgentCore runtime example
- add local smoke/unit tests and a documented tfvars config for the example
- document the example in `README.md` / `DEVELOPER_GUIDE.md` and add a `Makefile` test target

## Validation
- `make preflight-session` (PASS, run at start and before commit/push)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="examples/6-langgraph-baseline/agent-code" python3 -m pytest examples/6-langgraph-baseline/agent-code/tests/ -v --tb=short` (PASS, 8 tests)
- `PYTHONPATH="examples/6-langgraph-baseline/agent-code" python3 examples/6-langgraph-baseline/agent-code/runtime.py` (PASS)
- `bash terraform/scripts/validate_examples.sh` (initial FAIL on new `agent_name` pattern; fixed)
- `terraform -chdir=terraform plan -var-file=../examples/6-langgraph-baseline/terraform.tfvars -refresh=false -input=false` (post-fix result: only expected credential-source failure, no tfvars validation error)
- `git diff --check` (PASS)
- `python3 -m py_compile examples/6-langgraph-baseline/agent-code/runtime.py examples/6-langgraph-baseline/agent-code/tests/test_langgraph_runtime.py` (PASS)
- `terraform fmt -check examples/6-langgraph-baseline/terraform.tfvars` (PASS)

Closes #123
