### PR TITLE
docs: add documentation style and skill-use rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,19 @@ If AWS Knowledge MCP is unavailable, say so explicitly and fall back to official
 - Behavior, workflow, CI/CD, or architecture changes require doc updates in the same change.
 - Do not defer docs to a follow-up commit.
 
+### Rule 7.2.1: Documentation Style
+
+- Keep prose compact, structured, and low-noise. Prefer tightening existing sections over adding sprawling explanation.
+- Diagrams must use a consistent visual language across the active docs surface.
+- When a diagram is added or materially redesigned, commit the editable source with the rendered asset in the same change.
+- Prefer updating the current canonical docs over adding parallel improvement notes or replacement files.
+
+### Rule 7.2.2: Skill Use
+
+- When a local skill clearly matches the task, use it instead of re-creating the workflow from scratch.
+- Skill use must stay scoped and practical; do not load unrelated skills or expand task scope just because a skill exists.
+- When a skill materially changes the output shape or workflow, keep the resulting repo docs aligned in the same change.
+
 ### Rule 7.3: Scratch and New Files
 
 - Temporary outputs and one-off investigation files belong in `.scratch/` and must not be committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,19 @@ If AWS Knowledge MCP is unavailable, say so explicitly and fall back to official
 - Behavior, workflow, CI/CD, or architecture changes require doc updates in the same change.
 - Do not defer docs to a follow-up commit.
 
+### Rule 7.2.1: Documentation Style
+
+- Keep prose compact, structured, and low-noise. Prefer tightening existing sections over adding sprawling explanation.
+- Diagrams must use a consistent visual language across the active docs surface.
+- When a diagram is added or materially redesigned, commit the editable source with the rendered asset in the same change.
+- Prefer updating the current canonical docs over adding parallel improvement notes or replacement files.
+
+### Rule 7.2.2: Skill Use
+
+- When a local skill clearly matches the task, use it instead of re-creating the workflow from scratch.
+- Skill use must stay scoped and practical; do not load unrelated skills or expand task scope just because a skill exists.
+- When a skill materially changes the output shape or workflow, keep the resulting repo docs aligned in the same change.
+
 ### Rule 7.3: Scratch and New Files
 
 - Temporary outputs and one-off investigation files belong in `.scratch/` and must not be committed.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -61,6 +61,7 @@ Use [docs/runbooks/devops-loop.md](docs/runbooks/devops-loop.md) when deciding w
 Use [docs/archive/README.md](docs/archive/README.md) only for historical context, not for current workflow decisions.
 
 The repo is optimized for an issue-queue driven linked-worktree loop. The default path is short on purpose: pick ready work, allocate a worktree, iterate with the smallest validation lane that covers the touched scope, then finish with explicit PR and issue evidence.
+For documentation work, keep prose compact and reuse the repo's diagram style. When a local skill clearly matches the task, use it rather than improvising a parallel workflow.
 
 ![Developer harness loop](docs/diagrams/developer-loop.drawio.svg)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -167,6 +167,19 @@ If AWS Knowledge MCP is unavailable, say so explicitly and fall back to official
 - Behavior, workflow, CI/CD, or architecture changes require doc updates in the same change.
 - Do not defer docs to a follow-up commit.
 
+### Rule 7.2.1: Documentation Style
+
+- Keep prose compact, structured, and low-noise. Prefer tightening existing sections over adding sprawling explanation.
+- Diagrams must use a consistent visual language across the active docs surface.
+- When a diagram is added or materially redesigned, commit the editable source with the rendered asset in the same change.
+- Prefer updating the current canonical docs over adding parallel improvement notes or replacement files.
+
+### Rule 7.2.2: Skill Use
+
+- When a local skill clearly matches the task, use it instead of re-creating the workflow from scratch.
+- Skill use must stay scoped and practical; do not load unrelated skills or expand task scope just because a skill exists.
+- When a skill materially changes the output shape or workflow, keep the resulting repo docs aligned in the same change.
+
 ### Rule 7.3: Scratch and New Files
 
 - Temporary outputs and one-off investigation files belong in `.scratch/` and must not be committed.


### PR DESCRIPTION
Closes #140

## Summary
- add compact documentation style rules for prose and diagrams
- add a compact skill-use rule for matching local skills
- sync AGENTS.md, CLAUDE.md, and GEMINI.md
- reflect the new docs/skill expectation in the developer workflow guide

## Validation
- make preflight-session
- cmp -s AGENTS.md CLAUDE.md
- cmp -s AGENTS.md GEMINI.md
- git diff --check