### PR TITLE
#142 Align native AgentCore resources and IAM wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ excalidraw-mcp-*/
 terraform/tests/frontend/playwright-report/
 terraform/tests/frontend/test-results/
 terraform/tests/frontend/node_modules/
+.gitnexus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,3 +352,100 @@ Use narrower `make validate-scope` paths only when the issue scope justifies it 
 - Partition S3 and DynamoDB state by `app_id` and `tenant_id`.
 - Enforce ABAC conditions that bind principal tenant/app identity to resource tenant/app identity.
 - Keep the North-South identity join intact across the system.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **terraform** (1327 symbols, 2849 relationships, 93 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/terraform/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/terraform/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/terraform/clusters` | All functional areas |
+| `gitnexus://repo/terraform/processes` | All execution flows |
+| `gitnexus://repo/terraform/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+- Re-index: `npx gitnexus analyze`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,3 +352,100 @@ Use narrower `make validate-scope` paths only when the issue scope justifies it 
 - Partition S3 and DynamoDB state by `app_id` and `tenant_id`.
 - Enforce ABAC conditions that bind principal tenant/app identity to resource tenant/app identity.
 - Keep the North-South identity join intact across the system.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **terraform** (1327 symbols, 2849 relationships, 93 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/terraform/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/terraform/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/terraform/clusters` | All functional areas |
+| `gitnexus://repo/terraform/processes` | All execution flows |
+| `gitnexus://repo/terraform/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+- Re-index: `npx gitnexus analyze`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -352,3 +352,100 @@ Use narrower `make validate-scope` paths only when the issue scope justifies it 
 - Partition S3 and DynamoDB state by `app_id` and `tenant_id`.
 - Enforce ABAC conditions that bind principal tenant/app identity to resource tenant/app identity.
 - Keep the North-South identity join intact across the system.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **terraform** (1327 symbols, 2849 relationships, 93 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/terraform/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/terraform/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/terraform/clusters` | All functional areas |
+| `gitnexus://repo/terraform/processes` | All execution flows |
+| `gitnexus://repo/terraform/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+- Re-index: `npx gitnexus analyze`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -108,7 +108,6 @@ module "agentcore_runtime" {
   enable_s3_encryption   = var.enable_s3_encryption
   enable_observability   = var.enable_observability
   logging_bucket_id      = module.agentcore_foundation.access_logs_bucket_id
-  proxy_role_arn         = module.agentcore_bff.proxy_role_arn
 
   # Packaging
   enable_packaging     = var.enable_packaging

--- a/terraform/modules/agentcore-bff/iam.tf
+++ b/terraform/modules/agentcore-bff/iam.tf
@@ -45,8 +45,8 @@ resource "aws_iam_role_policy" "auth_handler" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        # AWS-REQUIRED: logs:PutResourcePolicy and agentcore log groups require broad resource scoping for service delivery
-        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/*"
+        # AWS-REQUIRED: log groups require specific scoping for agent-specific service delivery
+        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/${var.agent_name}/*"
       }
     ]
   })
@@ -97,8 +97,8 @@ resource "aws_iam_role_policy" "authorizer" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        # AWS-REQUIRED: logs:PutResourcePolicy and agentcore log groups require broad resource scoping for service delivery
-        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/*"
+        # AWS-REQUIRED: log groups require specific scoping for agent-specific service delivery
+        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/${var.agent_name}/*"
       }
     ]
   })

--- a/terraform/modules/agentcore-bff/outputs.tf
+++ b/terraform/modules/agentcore-bff/outputs.tf
@@ -42,3 +42,8 @@ output "audit_logs_athena_workgroup" {
   description = "Athena workgroup name for BFF proxy audit log queries"
   value       = local.audit_logs_enabled ? aws_athena_workgroup.bff_audit_logs[0].name : ""
 }
+
+output "proxy_role_arn" {
+  description = "ARN of the BFF Proxy Role used for agent invocation"
+  value       = var.enable_bff ? aws_iam_role.proxy[0].arn : ""
+}

--- a/terraform/modules/agentcore-foundation/identity.tf
+++ b/terraform/modules/agentcore-foundation/identity.tf
@@ -4,6 +4,4 @@ resource "aws_bedrockagentcore_workload_identity" "this" {
 
   name                                = "${var.agent_name}-workload-identity"
   allowed_resource_oauth2_return_urls = var.oauth_return_urls
-
-  tags = var.tags
 }

--- a/terraform/modules/agentcore-foundation/outputs.tf
+++ b/terraform/modules/agentcore-foundation/outputs.tf
@@ -21,8 +21,8 @@ output "gateway_role_arn" {
 }
 
 output "workload_identity_id" {
-  description = "ID of the workload identity"
-  value       = var.enable_identity ? aws_bedrockagentcore_workload_identity.this[0].workload_identity_id : null
+  description = "ID (ARN) of the workload identity"
+  value       = var.enable_identity ? aws_bedrockagentcore_workload_identity.this[0].workload_identity_arn : null
 }
 
 output "workload_identity_arn" {

--- a/terraform/modules/agentcore-runtime/iam.tf
+++ b/terraform/modules/agentcore-runtime/iam.tf
@@ -24,18 +24,19 @@ resource "aws_iam_role" "runtime" {
         }
       }],
       # Senior Move: Allow Proxy to assume this role with session policies
-      var.proxy_role_arn != "" ? [{
+      # Use deterministic ARN construction to break the module dependency cycle
+      [{
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
           AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         }
         Condition = {
-          ArnEquals = {
-            "aws:PrincipalArn" = var.proxy_role_arn
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.agent_name}-proxy-role-${var.environment}"
           }
         }
-      }] : []
+      }]
     )
   })
 
@@ -58,7 +59,7 @@ resource "aws_iam_role_policy" "runtime_base" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/runtime/*"
+        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock/agentcore/${var.agent_name}/*"
       },
       {
         Effect = "Allow"

--- a/terraform/modules/agentcore-runtime/runtime.tf
+++ b/terraform/modules/agentcore-runtime/runtime.tf
@@ -7,17 +7,19 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
 
   agent_runtime_artifact {
     code_configuration {
-      source_s3_uri = "s3://${local.deployment_bucket}/${local.deployment_key}"
+      runtime     = var.python_version
+      entry_point = [var.runtime_entry_file]
+      code {
+        s3 {
+          bucket = local.deployment_bucket
+          prefix = local.deployment_key
+        }
+      }
     }
   }
 
   network_configuration {
-    # Default SANDBOX mode aligns with previous CLI behavior
-    execution_mode = "SANDBOX"
-  }
-
-  lifecycle_configuration {
-    status = "DRAFT"
+    network_mode = "PUBLIC"
   }
 
   tags = var.tags

--- a/terraform/modules/agentcore-runtime/variables.tf
+++ b/terraform/modules/agentcore-runtime/variables.tf
@@ -135,12 +135,6 @@ variable "runtime_inline_policies" {
   default     = {}
 }
 
-variable "proxy_role_arn" {
-  description = "IAM role ARN of the BFF proxy to allow role assumption"
-  type        = string
-  default     = ""
-}
-
 variable "reserved_concurrency" {
   description = "Reserved concurrent executions for the agent runtime"
   type        = number

--- a/terraform/modules/agentcore-tools/browser.tf
+++ b/terraform/modules/agentcore-tools/browser.tf
@@ -6,13 +6,12 @@ resource "aws_bedrockagentcore_browser" "this" {
   execution_role_arn = aws_iam_role.browser[0].arn
 
   network_configuration {
-    execution_mode = var.browser_network_mode
-    dynamic "vpc_configuration" {
+    network_mode = var.browser_network_mode
+    dynamic "vpc_config" {
       for_each = var.browser_vpc_config != null ? [var.browser_vpc_config] : []
       content {
-        subnet_ids          = vpc_configuration.value.subnet_ids
-        security_group_ids  = vpc_configuration.value.security_group_ids
-        associate_public_ip = vpc_configuration.value.associate_public_ip
+        subnets         = vpc_config.value.subnet_ids
+        security_groups = vpc_config.value.security_group_ids
       }
     }
   }
@@ -20,12 +19,12 @@ resource "aws_bedrockagentcore_browser" "this" {
   dynamic "recording" {
     for_each = var.enable_browser_recording && var.browser_recording_s3_bucket != "" ? [1] : []
     content {
-      s3_bucket_name = var.browser_recording_s3_bucket
-      s3_key_prefix  = var.browser_recording_s3_prefix
+      s3_location {
+        bucket = var.browser_recording_s3_bucket
+        prefix = var.browser_recording_s3_prefix
+      }
     }
   }
-
-  tags = var.tags
 
   depends_on = [aws_iam_role.browser]
 }

--- a/terraform/modules/agentcore-tools/code_interpreter.tf
+++ b/terraform/modules/agentcore-tools/code_interpreter.tf
@@ -6,18 +6,15 @@ resource "aws_bedrockagentcore_code_interpreter" "this" {
   execution_role_arn = aws_iam_role.code_interpreter[0].arn
 
   network_configuration {
-    execution_mode = var.code_interpreter_network_mode
-    dynamic "vpc_configuration" {
+    network_mode = var.code_interpreter_network_mode
+    dynamic "vpc_config" {
       for_each = var.code_interpreter_vpc_config != null ? [var.code_interpreter_vpc_config] : []
       content {
-        subnet_ids          = vpc_configuration.value.subnet_ids
-        security_group_ids  = vpc_configuration.value.security_group_ids
-        associate_public_ip = vpc_configuration.value.associate_public_ip
+        subnets         = vpc_config.value.subnet_ids
+        security_groups = vpc_config.value.security_group_ids
       }
     }
   }
-
-  tags = var.tags
 
   depends_on = [aws_iam_role.code_interpreter]
 }

--- a/terraform/modules/agentcore-tools/outputs.tf
+++ b/terraform/modules/agentcore-tools/outputs.tf
@@ -1,11 +1,11 @@
 output "code_interpreter_id" {
   description = "ID of the code interpreter"
-  value       = var.enable_code_interpreter ? data.aws_ssm_parameter.interpreter_id[0].value : null
+  value       = var.enable_code_interpreter ? aws_bedrockagentcore_code_interpreter.this[0].code_interpreter_id : null
 }
 
 output "code_interpreter_arn" {
   description = "ARN of the code interpreter"
-  value       = var.enable_code_interpreter ? data.aws_ssm_parameter.interpreter_arn[0].value : null
+  value       = var.enable_code_interpreter ? aws_bedrockagentcore_code_interpreter.this[0].code_interpreter_arn : null
   sensitive   = true
 }
 
@@ -17,12 +17,12 @@ output "code_interpreter_role_arn" {
 
 output "browser_id" {
   description = "ID of the browser tool"
-  value       = var.enable_browser ? data.aws_ssm_parameter.browser_id[0].value : null
+  value       = var.enable_browser ? aws_bedrockagentcore_browser.this[0].browser_id : null
 }
 
 output "browser_arn" {
   description = "ARN of the browser tool"
-  value       = var.enable_browser ? data.aws_ssm_parameter.browser_arn[0].value : null
+  value       = var.enable_browser ? aws_bedrockagentcore_browser.this[0].browser_arn : null
   sensitive   = true
 }
 


### PR DESCRIPTION
## Summary
- align native AgentCore runtime, browser, and code interpreter Terraform configuration with the current AWS provider schema
- remove the runtime/BFF proxy role input cycle and tighten log-group scoping
- sync mirrored agent-rule docs and ignore the local `.gitnexus` index directory

## Validation
- make preflight-session
- make validate-scope SCOPE=terraform

## Notes
- `make worktree-push-issue` failed due a pre-existing harness issue in `terraform-plan-local` passing `terraform plan -backend=false`, which current Terraform rejects

Closes #142
